### PR TITLE
Travis-ci configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: java
+install: true
+jdk: oraclejdk8
+env:
+  matrix:
+  - TERM=dumb
+before_script:
+  - ./gradlew --version
+script: ./gradlew build

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Http Builder NG, The Easy Http Client for Groovy (and Java)
 
+[![Travis Build Status](http://img.shields.io/travis/dwclark/http-builder-ng.svg)](https://travis-ci.org/dwclark/http-builder-ng)
+
 ## Quick Links for the Impatient
 
 * Site: https://dwclark.github.io/http-builder-ng/


### PR DESCRIPTION
Instructions for enabling Travis to make a new build:
1. Log into  https://travis-ci.org/ using your GitHub account.
2. Locate the '+' on the left sidebar next to "My repositories".
3. Find "dwclark/http-builder-ng" and activate it.