### PR TITLE
Multipart Request Body Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build
 conftarget/
 *.iml
 .idea/
+classes/

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ subprojects {
     targetCompatibility = 8
 
     repositories {
+        mavenLocal()
         jcenter()
     }
 
@@ -58,7 +59,7 @@ subprojects {
         }
 
         testCompile 'org.spockframework:spock-core:1.0-groovy-2.4'
-        testCompile 'com.stehno.ersatz:ersatz:0.1.0'
+        testCompile 'com.stehno.ersatz:ersatz:0.2.0'
 
         asciidoclet 'org.asciidoctor:asciidoclet:1.+'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,6 @@ subprojects {
     targetCompatibility = 8
 
     repositories {
-        mavenLocal()
         jcenter()
     }
 

--- a/http-builder-ng-apache/build.gradle
+++ b/http-builder-ng-apache/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     compile project(':http-builder-ng-core')
 
     compile 'org.apache.httpcomponents:httpclient:4.5.2'
+    compile 'org.apache.httpcomponents:httpmime:4.5.2'
 
     testCompile project(path: ':http-builder-ng-core', configuration: 'testcode')
 }

--- a/http-builder-ng-apache/src/main/java/groovyx/net/http/ApacheEncoders.java
+++ b/http-builder-ng-apache/src/main/java/groovyx/net/http/ApacheEncoders.java
@@ -20,7 +20,6 @@ import org.apache.http.entity.ContentType;
 import org.apache.http.entity.mime.MultipartEntityBuilder;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.file.Path;
 
 import static org.apache.http.entity.ContentType.parse;

--- a/http-builder-ng-apache/src/main/java/groovyx/net/http/ApacheEncoders.java
+++ b/http-builder-ng-apache/src/main/java/groovyx/net/http/ApacheEncoders.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2016 David Clark
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package groovyx.net.http;
 
 import org.apache.commons.lang3.RandomStringUtils;
@@ -11,10 +26,18 @@ import java.nio.file.Path;
 import static org.apache.http.entity.ContentType.parse;
 
 /**
- * FIXME: document
+ * Request content encoders specific to the Apache client implementation.
  */
 public class ApacheEncoders {
 
+    // TODO: there is duplicate code in the multipart encoders - refactor to reduce duplication during parser/encoder work.
+
+    /**
+     *  Encodes multipart/form-data where the body content must be an instance of the {@link MultipartContent} class.
+     *
+     * @param config the chained configuration object
+     * @param ts the server adapter
+     */
     public static void multipart(final ChainedHttpConfig config, final ToServer ts) {
         try {
             final ChainedHttpConfig.ChainedRequest request = config.getChainedRequest();
@@ -28,8 +51,6 @@ public class ApacheEncoders {
             if (!contentType.equals(ContentTypes.MULTIPART_FORMDATA.getAt(0))) {
                 throw new IllegalArgumentException("Multipart body content must be multipart/form-data.");
             }
-
-            // FIXME: the stuff above is shared - reduce duplication
 
             final String boundary = RandomStringUtils.randomAlphanumeric(10);
             MultipartEntityBuilder entityBuilder = MultipartEntityBuilder.create().setBoundary(boundary);
@@ -48,9 +69,6 @@ public class ApacheEncoders {
 
                     } else if (mpe.getContent() instanceof Path) {
                         entityBuilder.addBinaryBody(mpe.getFieldName(), ((Path) mpe.getContent()).toFile(), partContentType, mpe.getFileName());
-
-                    } else if (mpe.getContent() instanceof InputStream) {
-                        entityBuilder.addBinaryBody(mpe.getFieldName(), (InputStream) mpe.getContent(), partContentType, mpe.getFileName());
 
                     } else if (mpe.getContent() instanceof byte[]) {
                         entityBuilder.addBinaryBody(mpe.getFieldName(), (byte[]) mpe.getContent(), partContentType, mpe.getFileName());

--- a/http-builder-ng-apache/src/main/java/groovyx/net/http/ApacheEncoders.java
+++ b/http-builder-ng-apache/src/main/java/groovyx/net/http/ApacheEncoders.java
@@ -29,8 +29,6 @@ import static org.apache.http.entity.ContentType.parse;
  */
 public class ApacheEncoders {
 
-    // TODO: there is duplicate code in the multipart encoders - refactor to reduce duplication during parser/encoder work.
-
     /**
      *  Encodes multipart/form-data where the body content must be an instance of the {@link MultipartContent} class.
      *

--- a/http-builder-ng-apache/src/main/java/groovyx/net/http/ApacheEncoders.java
+++ b/http-builder-ng-apache/src/main/java/groovyx/net/http/ApacheEncoders.java
@@ -1,0 +1,70 @@
+package groovyx.net.http;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.mime.MultipartEntityBuilder;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+
+import static org.apache.http.entity.ContentType.parse;
+
+/**
+ * FIXME: document
+ */
+public class ApacheEncoders {
+
+    public static void multipart(final ChainedHttpConfig config, final ToServer ts) {
+        try {
+            final ChainedHttpConfig.ChainedRequest request = config.getChainedRequest();
+
+            final Object body = request.actualBody();
+            if (!(body instanceof MultipartContent)) {
+                throw new IllegalArgumentException("Multipart body content must be MultipartContent.");
+            }
+
+            final String contentType = request.actualContentType();
+            if (!contentType.equals(ContentTypes.MULTIPART_FORMDATA.getAt(0))) {
+                throw new IllegalArgumentException("Multipart body content must be multipart/form-data.");
+            }
+
+            // FIXME: the stuff above is shared - reduce duplication
+
+            final String boundary = RandomStringUtils.randomAlphanumeric(10);
+            MultipartEntityBuilder entityBuilder = MultipartEntityBuilder.create().setBoundary(boundary);
+
+            entityBuilder.setContentType(ContentType.parse("multipart/mixed; boundary=" + boundary));
+
+            for (final MultipartContent.MultipartEntry mpe : ((MultipartContent) body).entries()) {
+                if (mpe.isField()) {
+                    entityBuilder.addTextBody(mpe.getFieldName(), (String) mpe.getContent());
+
+                } else {
+                    final ContentType partContentType = parse(mpe.getContentType());
+
+                    if (mpe.getContent() instanceof String) {
+                        entityBuilder.addBinaryBody(mpe.getFieldName(), ((String) mpe.getContent()).getBytes(), partContentType, mpe.getFileName());
+
+                    } else if (mpe.getContent() instanceof Path) {
+                        entityBuilder.addBinaryBody(mpe.getFieldName(), ((Path) mpe.getContent()).toFile(), partContentType, mpe.getFileName());
+
+                    } else if (mpe.getContent() instanceof InputStream) {
+                        entityBuilder.addBinaryBody(mpe.getFieldName(), (InputStream) mpe.getContent(), partContentType, mpe.getFileName());
+
+                    } else if (mpe.getContent() instanceof byte[]) {
+                        entityBuilder.addBinaryBody(mpe.getFieldName(), (byte[]) mpe.getContent(), partContentType, mpe.getFileName());
+
+                    } else {
+                        throw new IllegalArgumentException("Unsupported multipart content object type: " + mpe.getContent().getClass());
+                    }
+                }
+            }
+
+            ts.toServer(entityBuilder.build().getContent(), "multipart/mixed; boundary=" + boundary);
+
+        } catch (IOException ioe) {
+            ioe.printStackTrace();
+        }
+    }
+}

--- a/http-builder-ng-apache/src/test/groovy/groovyx/net/http/ApacheHttpPostSpec.groovy
+++ b/http-builder-ng-apache/src/test/groovy/groovyx/net/http/ApacheHttpPostSpec.groovy
@@ -24,15 +24,14 @@ import static groovyx.net.http.MultipartContent.multipart
 
 class ApacheHttpPostSpec extends HttpPostTestKit implements UsesApacheClient {
 
-    // FIXME: move to TK
+    // TODO: move this into TK during parser/encoder refactoring
     def 'POST /upload (multipart)'() {
         setup:
         ersatzServer.expectations {
             post('/upload') {
                 condition MultipartContentMatcher.multipart {
-                    // FIXME: needs to suport filename and contentType
-                    field(0, fieldName: 'alpha', string: 'some data')
-                    field(1, fieldName: 'bravo', string: 'This is bravo content')
+                    field 0, 'alpha', 'some data'
+                    file 1, 'bravo', 'bravo.txt', 'text/plain', 'This is bravo content'
                 }
                 responds().content('ok', TEXT_PLAIN)
             }

--- a/http-builder-ng-apache/src/test/groovy/groovyx/net/http/ApacheHttpPostSpec.groovy
+++ b/http-builder-ng-apache/src/test/groovy/groovyx/net/http/ApacheHttpPostSpec.groovy
@@ -15,8 +15,43 @@
  */
 package groovyx.net.http
 
+import com.stehno.ersatz.MultipartContentMatcher
 import groovyx.net.http.tk.HttpPostTestKit
+
+import static com.stehno.ersatz.ContentType.TEXT_PLAIN
+import static groovyx.net.http.ContentTypes.MULTIPART_FORMDATA
+import static groovyx.net.http.MultipartContent.multipart
 
 class ApacheHttpPostSpec extends HttpPostTestKit implements UsesApacheClient {
 
+    // FIXME: move to TK
+    def 'POST /upload (multipart)'() {
+        setup:
+        ersatzServer.expectations {
+            post('/upload') {
+                condition MultipartContentMatcher.multipart {
+                    // FIXME: needs to suport filename and contentType
+                    field(0, fieldName: 'alpha', string: 'some data')
+                    field(1, fieldName: 'bravo', string: 'This is bravo content')
+                }
+                responds().content('ok', TEXT_PLAIN)
+            }
+        }.start()
+
+        def config = {
+            request.uri.path = '/upload'
+            request.contentType = MULTIPART_FORMDATA[0]
+            request.body = multipart {
+                field 'alpha', 'some data'
+                file 'bravo', 'bravo.txt', 'text/plain', 'This is bravo content'
+            }
+            request.encoder(MULTIPART_FORMDATA, ApacheEncoders.&multipart)
+        }
+
+        expect:
+        httpBuilder(ersatzServer.port).post(config) == 'ok'
+
+        and:
+        httpBuilder(ersatzServer.port).postAsync(config).get() == 'ok'
+    }
 }

--- a/http-builder-ng-core/src/main/java/groovyx/net/http/ContentTypes.java
+++ b/http-builder-ng-core/src/main/java/groovyx/net/http/ContentTypes.java
@@ -35,7 +35,8 @@ public enum ContentTypes implements Iterable<String> {
     XML("application/xml", "text/xml", "application/xhtml+xml", "application/atom+xml"),
     HTML("text/html"),
     URLENC("application/x-www-form-urlencoded"),
-    BINARY("application/octet-stream");
+    BINARY("application/octet-stream"),
+    MULTIPART_FORMDATA("multipart/form-data");
 
     private final List<String> values;
 

--- a/http-builder-ng-core/src/main/java/groovyx/net/http/JavaHttpBuilder.java
+++ b/http-builder-ng-core/src/main/java/groovyx/net/http/JavaHttpBuilder.java
@@ -148,6 +148,12 @@ public class JavaHttpBuilder extends HttpBuilder {
                     throw new RuntimeException(e);
                 }
             }
+
+            @Override
+            public void toServer(final InputStream inputStream, final String contentType) {
+                // does not support contentType override
+                toServer(inputStream);
+            }
         }
 
         protected class JavaFromServer implements FromServer {

--- a/http-builder-ng-core/src/main/java/groovyx/net/http/MultipartContent.java
+++ b/http-builder-ng-core/src/main/java/groovyx/net/http/MultipartContent.java
@@ -1,0 +1,97 @@
+package groovyx.net.http;
+
+import groovy.lang.Closure;
+import groovy.lang.DelegatesTo;
+
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import static java.util.Collections.unmodifiableList;
+
+/**
+ * FIXME: document
+ */
+public class MultipartContent {
+
+    private final List<MultipartEntry> entries = new LinkedList<>();
+
+    public static MultipartContent multipart(@DelegatesTo(MultipartContent.class) Closure closure) {
+        MultipartContent content = new MultipartContent();
+        closure.setDelegate(content);
+        closure.call();
+        return content;
+    }
+
+    public static MultipartContent multipart(final Consumer<MultipartContent> config) {
+        MultipartContent content = new MultipartContent();
+        config.accept(content);
+        return content;
+    }
+
+    public MultipartContent field(String fieldName, String value) {
+        entries.add(new MultipartEntry(fieldName, null, null, value));
+        return this;
+    }
+
+    public MultipartContent file(String fieldName, String fileName, String contentType, String content) {
+        entries.add(new MultipartEntry(fieldName, fileName, contentType, content));
+        return this;
+    }
+
+    public MultipartContent file(String fieldName, String fileName, String contentType, Path content) {
+        entries.add(new MultipartEntry(fieldName, fileName, contentType, content));
+        return this;
+    }
+
+    public MultipartContent file(String fieldName, String fileName, String contentType, InputStream content) {
+        entries.add(new MultipartEntry(fieldName, fileName, contentType, content));
+        return this;
+    }
+
+    public MultipartContent file(String fieldName, String fileName, String contentType, byte[] content) {
+        entries.add(new MultipartEntry(fieldName, fileName, contentType, content));
+        return this;
+    }
+
+    public Iterable<MultipartEntry> entries() {
+        return unmodifiableList(entries);
+    }
+
+    public static class MultipartEntry {
+
+        private final String fieldName;
+        private final String fileName;
+        private final String contentType;
+        private final Object content;
+
+        private MultipartEntry(String fieldName, String fileName, String contentType, Object content) {
+            this.fieldName = fieldName;
+            this.fileName = fileName;
+            this.contentType = contentType;
+            this.content = content;
+        }
+
+        public boolean isField() {
+            return fileName == null;
+        }
+
+        public String getFieldName() {
+            return fieldName;
+        }
+
+        public String getFileName() {
+            return fileName;
+        }
+
+        public String getContentType() {
+            return contentType;
+        }
+
+        public Object getContent() {
+            return content;
+        }
+    }
+}

--- a/http-builder-ng-core/src/main/java/groovyx/net/http/MultipartContent.java
+++ b/http-builder-ng-core/src/main/java/groovyx/net/http/MultipartContent.java
@@ -1,9 +1,23 @@
+/**
+ * Copyright (C) 2016 David Clark
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package groovyx.net.http;
 
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 
-import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.LinkedList;
 import java.util.List;
@@ -12,12 +26,29 @@ import java.util.function.Consumer;
 import static java.util.Collections.unmodifiableList;
 
 /**
- * FIXME: document
+ * Multipart request content object used to define the multipart data. An example would be:
+ *
+ * [source,groovy]
+ * ----
+ * request.contentType = 'multipart/form-data'
+ * request.body = multipart {
+ *     field 'userid','someuser'
+ *     file 'icon','user-icon.jpg', 'image/jpeg', imageFile
+ * }
+ * ----
+ *
+ * which would define a `multipart/form-data` request with a field part and a file part with the specified properties.
  */
 public class MultipartContent {
 
     private final List<MultipartEntry> entries = new LinkedList<>();
 
+    /**
+     * Configures multipart request content using a Groovy closure (delegated to {@link MultipartContent}).
+     *
+     * @param closure the configuration closure
+     * @return a configured instance of {@link MultipartContent}
+     */
     public static MultipartContent multipart(@DelegatesTo(MultipartContent.class) Closure closure) {
         MultipartContent content = new MultipartContent();
         closure.setDelegate(content);
@@ -25,42 +56,81 @@ public class MultipartContent {
         return content;
     }
 
+    /**
+     * Configures multipart request content using a {@link Consumer} which will have an instance of {@link MultipartContent} passed into it for
+     * configuring the multipart content data.
+     *
+     * @param config the configuration {@link Consumer}
+     * @return a configured instance of {@link MultipartContent}
+     */
     public static MultipartContent multipart(final Consumer<MultipartContent> config) {
         MultipartContent content = new MultipartContent();
         config.accept(content);
         return content;
     }
 
+    /**
+     * Adds a text field part with the specified name and value.
+     *
+     * @param fieldName the field name
+     * @param value the text value
+     * @return a reference to this {@link MultipartContent} instance
+     */
     public MultipartContent field(String fieldName, String value) {
         entries.add(new MultipartEntry(fieldName, null, null, value));
         return this;
     }
 
+    /**
+     * Adds a file part with the specified properties.
+     *
+     * @param fieldName the field name
+     * @param fileName the file name
+     * @param contentType the content type of the part
+     * @param content the text content of the part
+     * @return a reference to this {@link MultipartContent} instance
+     */
     public MultipartContent file(String fieldName, String fileName, String contentType, String content) {
         entries.add(new MultipartEntry(fieldName, fileName, contentType, content));
         return this;
     }
 
+    /**
+     * Adds a file part with the specified properties.
+     *
+     * @param fieldName the field name
+     * @param fileName the file name
+     * @param contentType the content type of the part
+     * @param content the content of the part
+     * @return a reference to this {@link MultipartContent} instance
+     */
     public MultipartContent file(String fieldName, String fileName, String contentType, Path content) {
         entries.add(new MultipartEntry(fieldName, fileName, contentType, content));
         return this;
     }
 
-    public MultipartContent file(String fieldName, String fileName, String contentType, InputStream content) {
-        entries.add(new MultipartEntry(fieldName, fileName, contentType, content));
-        return this;
-    }
-
+    /**
+     * Adds a file part with the specified properties.
+     *
+     * @param fieldName the field name
+     * @param fileName the file name
+     * @param contentType the content type of the part
+     * @param content the content of the part
+     * @return a reference to this {@link MultipartContent} instance
+     */
     public MultipartContent file(String fieldName, String fileName, String contentType, byte[] content) {
         entries.add(new MultipartEntry(fieldName, fileName, contentType, content));
         return this;
     }
 
-    public Iterable<MultipartEntry> entries() {
+    Iterable<MultipartEntry> entries() {
         return unmodifiableList(entries);
     }
 
-    public static class MultipartEntry {
+    /**
+     * Represents a single multipart part.
+     */
+    static class MultipartEntry {
 
         private final String fieldName;
         private final String fileName;

--- a/http-builder-ng-core/src/main/java/groovyx/net/http/ToServer.java
+++ b/http-builder-ng-core/src/main/java/groovyx/net/http/ToServer.java
@@ -24,13 +24,18 @@ import java.io.InputStream;
 public interface ToServer {
 
     /**
-     * Translates the request content appropriately for the underlying client implementation.
+     * Translates the request content appropriately for the underlying client implementation. The contentType will be determined by the request.
      *
      * @param inputStream the request input stream to be translated.
      */
     void toServer(InputStream inputStream);
 
-    default void setContentType(String contentType){
-        // FIXME: implement in all
-    }
+    /**
+     * Translates the request content appropriately for the underlying client implementation. The provided contentType will override any specified in
+     * the request.
+     *
+     * @param inputStream the request input stream to be translated.
+     * @param contentType the overriding content type.
+     */
+    void toServer(InputStream inputStream, String contentType);
 }

--- a/http-builder-ng-core/src/main/java/groovyx/net/http/ToServer.java
+++ b/http-builder-ng-core/src/main/java/groovyx/net/http/ToServer.java
@@ -29,4 +29,8 @@ public interface ToServer {
      * @param inputStream the request input stream to be translated.
      */
     void toServer(InputStream inputStream);
+
+    default void setContentType(String contentType){
+        // FIXME: implement in all
+    }
 }

--- a/http-builder-ng-core/src/main/java/groovyx/net/http/optional/Html.java
+++ b/http-builder-ng-core/src/main/java/groovyx/net/http/optional/Html.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2016 David Clark
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,54 +16,73 @@
 package groovyx.net.http.optional;
 
 import groovy.util.XmlSlurper;
-import groovy.util.slurpersupport.GPathResult;
-import groovyx.net.http.*;
+import groovyx.net.http.ChainedHttpConfig;
+import groovyx.net.http.FromServer;
+import groovyx.net.http.NativeHandlers;
+import groovyx.net.http.ToServer;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.xml.sax.SAXException;
+import org.xml.sax.XMLReader;
+
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
-import org.jsoup.Jsoup;
-import org.jsoup.nodes.Document;
-import org.xml.sax.SAXException;
-import org.xml.sax.XMLReader;
-import static groovyx.net.http.NativeHandlers.Encoders.stringToStream;
-import static groovyx.net.http.NativeHandlers.Encoders.handleRawUpload;
 
+import static groovyx.net.http.NativeHandlers.Encoders.handleRawUpload;
+import static groovyx.net.http.NativeHandlers.Encoders.stringToStream;
+
+/**
+ * Parser and Encoder methods for handling HTML content using the https://jsoup.org/[JSoup] HTML library.
+ */
 public class Html {
 
-    public static final Supplier<BiFunction<ChainedHttpConfig,FromServer,Object>> neckoParserSupplier = () -> Html::neckoParse;
-    public static final Supplier<BiConsumer<ChainedHttpConfig,ToServer>> jsoupEncoderSupplier = () -> Html::jsoupEncode;
-    public static final Supplier<BiFunction<ChainedHttpConfig,FromServer,Object>> jsoupParserSupplier = () -> Html::jsoupParse;
-    
+    public static final Supplier<BiFunction<ChainedHttpConfig, FromServer, Object>> neckoParserSupplier = () -> Html::neckoParse;
+
+    public static final Supplier<BiConsumer<ChainedHttpConfig, ToServer>> jsoupEncoderSupplier = () -> Html::jsoupEncode;
+
+    public static final Supplier<BiFunction<ChainedHttpConfig, FromServer, Object>> jsoupParserSupplier = () -> Html::jsoupParse;
+
+    /**
+     * Method that provides an HTML parser for response configuration (uses necko parser).
+     *
+     * @param config the chained configuration
+     * @param fromServer the server response adapter
+     * @return the parsed HTML content (a {@link groovy.util.slurpersupport.GPathResult} object)
+     */
     public static Object neckoParse(final ChainedHttpConfig config, final FromServer fromServer) {
         try {
             final XMLReader p = new org.cyberneko.html.parsers.SAXParser();
             p.setEntityResolver(NativeHandlers.Parsers.catalogResolver);
             return new XmlSlurper(p).parse(new InputStreamReader(fromServer.getInputStream(), fromServer.getCharset()));
-        }
-        catch(IOException | SAXException ex) {
+        } catch (IOException | SAXException ex) {
             throw new RuntimeException(ex);
         }
     }
-    
+
+    /**
+     * Method that provides an HTML parser for response configuration (uses JSoup).
+     *
+     * @param config the chained configuration
+     * @param fromServer the server response adapter
+     * @return the parsed HTML content (a {@link Document} object)
+     */
     public static Object jsoupParse(final ChainedHttpConfig config, final FromServer fromServer) {
         try {
-            return Jsoup.parse(fromServer.getInputStream(),
-                               fromServer.getCharset().name(),
-                               fromServer.getUri().toString());
-        }
-        catch(IOException e) {
+            return Jsoup.parse(fromServer.getInputStream(), fromServer.getCharset().name(), fromServer.getUri().toString());
+        } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }
 
     public static void jsoupEncode(final ChainedHttpConfig config, final ToServer ts) {
         final ChainedHttpConfig.ChainedRequest request = config.getChainedRequest();
-        if(handleRawUpload(config, ts)) {
+        if (handleRawUpload(config, ts)) {
             return;
         }
-        
+
         final Document document = (Document) request.actualBody();
         ts.toServer(stringToStream(document.text(), request.actualCharset()));
     }

--- a/http-builder-ng-core/src/main/java/groovyx/net/http/optional/Jackson.java
+++ b/http-builder-ng-core/src/main/java/groovyx/net/http/optional/Jackson.java
@@ -24,7 +24,7 @@ import java.io.StringWriter;
 import static groovyx.net.http.NativeHandlers.Encoders.handleRawUpload;
 
 /**
- * Helper class for handling JSON content using the https://github.com/FasterXML/jackson[Jackson] JSON library.
+ * Parser and Encoder methods for handling JSON content using the https://github.com/FasterXML/jackson[Jackson] JSON library.
  */
 public class Jackson {
 

--- a/http-builder-ng-core/src/test/groovy/groovyx/net/http/JavaUsageTest.java
+++ b/http-builder-ng-core/src/test/groovy/groovyx/net/http/JavaUsageTest.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2016 David Clark
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/http-builder-ng-core/src/test/groovy/groovyx/net/http/optional/HtmlSpec.groovy
+++ b/http-builder-ng-core/src/test/groovy/groovyx/net/http/optional/HtmlSpec.groovy
@@ -1,0 +1,44 @@
+package groovyx.net.http.optional
+
+import com.stehno.ersatz.ErsatzServer
+import groovyx.net.http.HttpBuilder
+import spock.lang.AutoCleanup
+import spock.lang.Specification
+
+class HtmlSpec extends Specification {
+
+    @AutoCleanup('stop') private final ErsatzServer ersatzServer = new ErsatzServer()
+    private static final String HTML_CONTENT = '<html><body><p>This is HTML!</p></body></html>'
+    private static final String CONTENT_TYPE = 'web/content'
+
+    def setup() {
+        ersatzServer.expectations {
+            get('/html').responds().content(HTML_CONTENT, CONTENT_TYPE)
+        }.start()
+    }
+
+    // FIXME: these both pass, but they are not using the expected parsers
+    // - these need to be addressed during the parser/encoder refactoring.
+
+    def 'use necko parser'() {
+        given:
+        def http = HttpBuilder.configure {
+            request.uri = "${ersatzServer.serverUrl}/html"
+            response.parser([CONTENT_TYPE], Html.&neckoParse)
+        }
+
+        expect:
+        http.get().text() == 'This is HTML!'
+    }
+
+    def 'use jsoup parser'() {
+        given:
+        def http = HttpBuilder.configure {
+            request.uri = "${ersatzServer.serverUrl}/html"
+            response.parser([CONTENT_TYPE], Html.&jsoupParse)
+        }
+
+        expect:
+        http.get().getElementsByTag('p').text() == 'This is HTML!'
+    }
+}

--- a/http-builder-ng-core/src/test/groovy/groovyx/net/http/tk/HttpPostTestKit.groovy
+++ b/http-builder-ng-core/src/test/groovy/groovyx/net/http/tk/HttpPostTestKit.groovy
@@ -15,7 +15,6 @@
  */
 package groovyx.net.http.tk
 
-import com.stehno.ersatz.MultipartContentMatcher
 import com.stehno.ersatz.feat.BasicAuthFeature
 import groovy.json.JsonSlurper
 import groovyx.net.http.ChainedHttpConfig
@@ -29,7 +28,6 @@ import spock.lang.Unroll
 import static com.stehno.ersatz.ContentType.APPLICATION_URLENCODED
 import static com.stehno.ersatz.ContentType.TEXT_PLAIN
 import static groovyx.net.http.ContentTypes.*
-import static groovyx.net.http.MultipartContent.multipart
 
 /**
  * Test kit for testing the HTTP POST method with different clients.

--- a/http-builder-ng-core/src/test/groovy/groovyx/net/http/tk/HttpPostTestKit.groovy
+++ b/http-builder-ng-core/src/test/groovy/groovyx/net/http/tk/HttpPostTestKit.groovy
@@ -64,7 +64,6 @@ abstract class HttpPostTestKit extends HttpMethodTestKit {
                 converter(JSON[0] as String, { b -> new JsonSlurper().parse(b) })
                 responder {
                     content('{"name":"Bob","age":42}', JSON[0])
-                    //                    content(JSON_STRING, JSON[0]) // TODO: bug in ersatz?
                 }
             }
         }.start()

--- a/http-builder-ng-okhttp/src/main/java/groovyx/net/http/OkHttpBuilder.java
+++ b/http-builder-ng-okhttp/src/main/java/groovyx/net/http/OkHttpBuilder.java
@@ -302,10 +302,14 @@ public class OkHttpBuilder extends HttpBuilder {
 
     private static class OkHttpToServer extends RequestBody implements ToServer {
 
-        private final String contentType;
+        private String contentType;
         private InputStream inputStream;
 
         private OkHttpToServer(final String contentType) {
+            this.contentType = contentType;
+        }
+
+        public void setContentType(final String contentType){
             this.contentType = contentType;
         }
 

--- a/http-builder-ng-okhttp/src/main/java/groovyx/net/http/OkHttpBuilder.java
+++ b/http-builder-ng-okhttp/src/main/java/groovyx/net/http/OkHttpBuilder.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2016 David Clark
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -309,13 +309,15 @@ public class OkHttpBuilder extends HttpBuilder {
             this.contentType = contentType;
         }
 
-        public void setContentType(final String contentType){
-            this.contentType = contentType;
-        }
-
         @Override
         public void toServer(final InputStream inputStream) {
             this.inputStream = inputStream;
+        }
+
+        @Override
+        public void toServer(final InputStream inputStream, final String contentType) {
+            this.contentType = contentType;
+            toServer(inputStream);
         }
 
         @Override

--- a/http-builder-ng-okhttp/src/main/java/groovyx/net/http/OkHttpBuilder.java
+++ b/http-builder-ng-okhttp/src/main/java/groovyx/net/http/OkHttpBuilder.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2016 David Clark
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/http-builder-ng-okhttp/src/main/java/groovyx/net/http/OkHttpEncoders.java
+++ b/http-builder-ng-okhttp/src/main/java/groovyx/net/http/OkHttpEncoders.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2016 David Clark
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package groovyx.net.http;
 
 import okhttp3.MultipartBody;
@@ -5,17 +20,28 @@ import okhttp3.RequestBody;
 import okio.Buffer;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.file.Path;
 
 import static okhttp3.MediaType.parse;
 import static okhttp3.RequestBody.create;
 
 /**
- * FIXME: document
+ * Request content encoders specific to the Apache client implementation.
  */
 public class OkHttpEncoders {
 
+    // TODO: there is duplicate code in the multipart encoders - refactor to reduce duplication during parser/encoder work.
+
+    // FIXME: document (form and upload)
+    // FIXME: testing
+    // FIXME: go through TODO/FIXME tags
+
+    /**
+     * Encodes multipart/form-data where the body content must be an instance of the {@link MultipartContent} class.
+     *
+     * @param config the chained configuration object
+     * @param ts     the server adapter
+     */
     public static void multipart(final ChainedHttpConfig config, final ToServer ts) {
         try {
             final ChainedHttpConfig.ChainedRequest request = config.getChainedRequest();
@@ -43,10 +69,6 @@ public class OkHttpEncoders {
 
                     } else if (mpe.getContent() instanceof Path) {
                         requestBody = create(parse(mpe.getContentType()), ((Path) mpe.getContent()).toFile());
-
-                    } else if (mpe.getContent() instanceof InputStream) {
-                        // FIXME: finish supporting this
-//                        requestBody = create(parse(mpe.getContentType()), );
 
                     } else if (mpe.getContent() instanceof byte[]) {
                         requestBody = create(parse(mpe.getContentType()), (byte[]) mpe.getContent());

--- a/http-builder-ng-okhttp/src/main/java/groovyx/net/http/OkHttpEncoders.java
+++ b/http-builder-ng-okhttp/src/main/java/groovyx/net/http/OkHttpEncoders.java
@@ -1,0 +1,75 @@
+package groovyx.net.http;
+
+import okhttp3.MultipartBody;
+import okhttp3.RequestBody;
+import okio.Buffer;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+
+import static okhttp3.MediaType.parse;
+import static okhttp3.RequestBody.create;
+
+/**
+ * FIXME: document
+ */
+public class OkHttpEncoders {
+
+    public static void multipart(final ChainedHttpConfig config, final ToServer ts) {
+        try {
+            final ChainedHttpConfig.ChainedRequest request = config.getChainedRequest();
+
+            final Object body = request.actualBody();
+            if (!(body instanceof MultipartContent)) {
+                throw new IllegalArgumentException("Multipart body content must be MultipartContent.");
+            }
+
+            final String contentType = request.actualContentType();
+            if (!contentType.equals(ContentTypes.MULTIPART_FORMDATA.getAt(0))) {
+                throw new IllegalArgumentException("Multipart body content must be multipart/form-data.");
+            }
+
+//            final Charset charset = request.actualCharset();
+
+            final MultipartBody.Builder builder = new MultipartBody.Builder();
+
+            for (final MultipartContent.MultipartEntry mpe : ((MultipartContent) body).entries()) {
+                if (mpe.isField()) {
+                    builder.addFormDataPart(mpe.getFieldName(), (String) mpe.getContent());
+                } else {
+                    RequestBody requestBody = null;
+
+                    if (mpe.getContent() instanceof String) {
+                        requestBody = create(parse(mpe.getContentType()), (String) mpe.getContent());
+
+                    } else if (mpe.getContent() instanceof Path) {
+                        requestBody = create(parse(mpe.getContentType()), ((Path) mpe.getContent()).toFile());
+
+                    } else if (mpe.getContent() instanceof InputStream) {
+                        // FIXME: finish supporting this
+//                        requestBody = create(parse(mpe.getContentType()), );
+
+                    } else if (mpe.getContent() instanceof byte[]) {
+                        requestBody = create(parse(mpe.getContentType()), (byte[]) mpe.getContent());
+
+                    } else {
+                        throw new IllegalArgumentException("Unsupported multipart content object type: " + mpe.getContent().getClass());
+                    }
+
+                    builder.addFormDataPart(mpe.getFieldName(), mpe.getFileName(), requestBody);
+                }
+            }
+
+            final Buffer buffer = new Buffer();
+            MultipartBody multipartBody = builder.build();
+            multipartBody.writeTo(buffer);
+
+            ts.setContentType("multipart/mixed; boundary=" + multipartBody.boundary());
+            ts.toServer(buffer.inputStream());
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/http-builder-ng-okhttp/src/main/java/groovyx/net/http/OkHttpEncoders.java
+++ b/http-builder-ng-okhttp/src/main/java/groovyx/net/http/OkHttpEncoders.java
@@ -32,8 +32,7 @@ public class OkHttpEncoders {
 
     // TODO: there is duplicate code in the multipart encoders - refactor to reduce duplication during parser/encoder work.
 
-    // FIXME: document (form and upload)
-    // FIXME: testing
+    // FIXME: testing the encoders (check coverage)
     // FIXME: go through TODO/FIXME tags
 
     /**

--- a/http-builder-ng-okhttp/src/main/java/groovyx/net/http/OkHttpEncoders.java
+++ b/http-builder-ng-okhttp/src/main/java/groovyx/net/http/OkHttpEncoders.java
@@ -30,8 +30,6 @@ public class OkHttpEncoders {
                 throw new IllegalArgumentException("Multipart body content must be multipart/form-data.");
             }
 
-//            final Charset charset = request.actualCharset();
-
             final MultipartBody.Builder builder = new MultipartBody.Builder();
 
             for (final MultipartContent.MultipartEntry mpe : ((MultipartContent) body).entries()) {
@@ -65,8 +63,7 @@ public class OkHttpEncoders {
             MultipartBody multipartBody = builder.build();
             multipartBody.writeTo(buffer);
 
-            ts.setContentType("multipart/mixed; boundary=" + multipartBody.boundary());
-            ts.toServer(buffer.inputStream());
+            ts.toServer(buffer.inputStream(), "multipart/mixed; boundary=" + multipartBody.boundary());
 
         } catch (IOException e) {
             e.printStackTrace();

--- a/http-builder-ng-okhttp/src/main/java/groovyx/net/http/OkHttpEncoders.java
+++ b/http-builder-ng-okhttp/src/main/java/groovyx/net/http/OkHttpEncoders.java
@@ -30,11 +30,6 @@ import static okhttp3.RequestBody.create;
  */
 public class OkHttpEncoders {
 
-    // TODO: there is duplicate code in the multipart encoders - refactor to reduce duplication during parser/encoder work.
-
-    // FIXME: testing the encoders (check coverage)
-    // FIXME: go through TODO/FIXME tags
-
     /**
      * Encodes multipart/form-data where the body content must be an instance of the {@link MultipartContent} class.
      *

--- a/http-builder-ng-okhttp/src/test/groovy/groovyx/net/http/OkHttpPostSpec.groovy
+++ b/http-builder-ng-okhttp/src/test/groovy/groovyx/net/http/OkHttpPostSpec.groovy
@@ -18,25 +18,20 @@ package groovyx.net.http
 import com.stehno.ersatz.MultipartContentMatcher
 import groovyx.net.http.tk.HttpPostTestKit
 
-import static com.stehno.ersatz.ContentType.getTEXT_PLAIN
+import static com.stehno.ersatz.ContentType.TEXT_PLAIN
 import static groovyx.net.http.ContentTypes.MULTIPART_FORMDATA
 import static groovyx.net.http.MultipartContent.multipart
 
 class OkHttpPostSpec extends HttpPostTestKit implements UsesOkClient {
 
-    // FIXME: implement upload
-    // FIXME: move to testkit
-    // FIXME: refactoring and cleanup
-    // FIXME: document (form and upload)
-
+    // TODO: move this into TK during parser/encoder refactoring
     def 'POST /upload (multipart)'() {
         setup:
         ersatzServer.expectations {
             post('/upload') {
                 condition MultipartContentMatcher.multipart {
-                    // FIXME: needs to suport filename and contentType
-                    field(0, fieldName: 'alpha', string: 'some data')
-                    field(1, fieldName: 'bravo', string: 'This is bravo content')
+                    field 0, 'alpha', 'some data'
+                    file 1, 'bravo', 'bravo.txt', 'text/plain', 'This is bravo content'
                 }
                 responds().content('ok', TEXT_PLAIN)
             }

--- a/http-builder-ng-okhttp/src/test/groovy/groovyx/net/http/OkHttpPostSpec.groovy
+++ b/http-builder-ng-okhttp/src/test/groovy/groovyx/net/http/OkHttpPostSpec.groovy
@@ -15,8 +15,47 @@
  */
 package groovyx.net.http
 
+import com.stehno.ersatz.MultipartContentMatcher
 import groovyx.net.http.tk.HttpPostTestKit
+
+import static com.stehno.ersatz.ContentType.getTEXT_PLAIN
+import static groovyx.net.http.ContentTypes.MULTIPART_FORMDATA
+import static groovyx.net.http.MultipartContent.multipart
 
 class OkHttpPostSpec extends HttpPostTestKit implements UsesOkClient {
 
+    // FIXME: implement upload
+    // FIXME: move to testkit
+    // FIXME: refactoring and cleanup
+    // FIXME: document (form and upload)
+
+    def 'POST /upload (multipart)'() {
+        setup:
+        ersatzServer.expectations {
+            post('/upload') {
+                condition MultipartContentMatcher.multipart {
+                    // FIXME: needs to suport filename and contentType
+                    field(0, fieldName: 'alpha', string: 'some data')
+                    field(1, fieldName: 'bravo', string: 'This is bravo content')
+                }
+                responds().content('ok', TEXT_PLAIN)
+            }
+        }.start()
+
+        def config = {
+            request.uri.path = '/upload'
+            request.contentType = MULTIPART_FORMDATA[0]
+            request.body = multipart {
+                field 'alpha', 'some data'
+                file 'bravo', 'bravo.txt', 'text/plain', 'This is bravo content'
+            }
+            request.encoder(MULTIPART_FORMDATA, OkHttpEncoders.&multipart)
+        }
+
+        expect:
+        httpBuilder(ersatzServer.port).post(config) == 'ok'
+
+        and:
+        httpBuilder(ersatzServer.port).postAsync(config).get() == 'ok'
+    }
 }

--- a/http-builder-ng-okhttp/src/test/groovy/groovyx/net/http/OkHttpPutSpec.groovy
+++ b/http-builder-ng-okhttp/src/test/groovy/groovyx/net/http/OkHttpPutSpec.groovy
@@ -15,8 +15,42 @@
  */
 package groovyx.net.http
 
+import com.stehno.ersatz.MultipartContentMatcher
 import groovyx.net.http.tk.HttpPutTestKit
+
+import static com.stehno.ersatz.ContentType.TEXT_PLAIN
+import static groovyx.net.http.ContentTypes.MULTIPART_FORMDATA
+import static groovyx.net.http.MultipartContent.multipart
 
 class OkHttpPutSpec extends HttpPutTestKit implements UsesOkClient {
 
+    // TODO: move this into TK during parser/encoder refactoring
+    def 'PUT /upload (multipart)'() {
+        setup:
+        ersatzServer.expectations {
+            put('/upload') {
+                condition MultipartContentMatcher.multipart {
+                    field 0, 'alpha', 'some data'
+                    file 1, 'bravo', 'bravo.txt', 'text/plain', 'This is bravo content'
+                }
+                responds().content('ok', TEXT_PLAIN)
+            }
+        }.start()
+
+        def config = {
+            request.uri.path = '/upload'
+            request.contentType = MULTIPART_FORMDATA[0]
+            request.body = multipart {
+                field 'alpha', 'some data'
+                file 'bravo', 'bravo.txt', 'text/plain', 'This is bravo content'
+            }
+            request.encoder(MULTIPART_FORMDATA, OkHttpEncoders.&multipart)
+        }
+
+        expect:
+        httpBuilder(ersatzServer.port).put(config) == 'ok'
+
+        and:
+        httpBuilder(ersatzServer.port).putAsync(config).get() == 'ok'
+    }
 }

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,6 +1,6 @@
 = Http Builder NG Users Guide
 David Clark & Christopher J. Stehno
-v0.11.1, November 2016
+v0.11.1, December 2016
 :toc: left
 :toclevels: 3
 
@@ -426,3 +426,62 @@ The additional `.json` property call on the parsed data is to extract the JSON d
 the request. The end result is the following display:
 
     Your score for item (ASDFASEACV235) was (90786).
+
+=== Sending Form Data (POST)
+
+Posting HTML form data is a common `POST` operation, and it is supported by `HttpBuilder` with a custom encoder, such as:
+
+[source,groovy]
+----
+HttpBuilder.configure {
+    request.uri = 'http://example.com'
+}.post {
+    request.uri.path = '/some/form'
+    request.body = [id: '234545', label: 'something interesting']
+    request.contentType = 'application/x-www-form-urlencoded'
+    request.encoder 'application/x-www-form-urlencoded', NativeHandlers.Encoders.&form
+}
+----
+
+which would `POST` the specified body data map as urlencoded data to the server. The key here is the use of the `NativeHandlers.Encoders.&form`
+encoder, which converts the provided map data into the encoded message before sending it to the server.
+
+=== Sending Multipart Data (POST)
+
+`HttpBuilder` supports multipart request content such as file uploads, but only with the Apache or OkHttp client implementations, not the core Java
+implementation. File uploads may be configured as (using the `OkHttpBuilder` implementation):
+
+[source,groovy]
+----
+File someFile = // ...
+
+OkHttpBuilder.configure {
+    request.uri = 'http://example.com'
+}.post {
+    request.uri.path = '/upload'
+    request.contentType = 'multipart/form-data'
+    request.body = multipart {
+        field 'name', 'This is my file'
+        file 'file', 'myfile.txt', 'text/plain', someFile
+    }
+    request.encoder 'multipart/form-data', OkHttpEncoders.&multipart
+}
+----
+
+which would `POST` the content of the file, `someFile` along with the specified `name` field to the server as a `multipart/form-data` request. The
+important parts of the example are the `multipart` DSL extension, which is provided by the `MultipartContent` class and aids in creating the upload
+content in the correct format. The multipart encoder is used to convert the request content into the multipart message format expected by a server.
+Notice that the encoder is specific to the `OkHttpBuilder`, which we are using in this case.
+
+== Appendix A: Feature Support
+
+The goal is to support all features across all client implementations; however, due to the nature of the client implemeatations, this is not always
+possible. The table below contains general feature support information per client implementation.
+
+.Table Feature Support Matrix
+|===
+|Client |BASIC  |DIGEST |Multipart
+|Java   |Y      |?      |N
+|Apache |Y      |?      |Y
+|OkHttp |Y      |?      |Y
+|===

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -478,7 +478,7 @@ Notice that the encoder is specific to the `OkHttpBuilder`, which we are using i
 The goal is to support all features across all client implementations; however, due to the nature of the client implemeatations, this is not always
 possible. The table below contains general feature support information per client implementation.
 
-.Table Feature Support Matrix
+.Feature Support Matrix
 |===
 |Client |BASIC  |DIGEST |Multipart  |Compression
 |Java   |Y      |?      |N          |Y

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -480,8 +480,8 @@ possible. The table below contains general feature support information per clien
 
 .Table Feature Support Matrix
 |===
-|Client |BASIC  |DIGEST |Multipart
-|Java   |Y      |?      |N
-|Apache |Y      |?      |Y
-|OkHttp |Y      |?      |Y
+|Client |BASIC  |DIGEST |Multipart  |Compression
+|Java   |Y      |?      |N          |Y
+|Apache |Y      |?      |Y          |Y
+|OkHttp |Y      |?      |Y          |N
 |===


### PR DESCRIPTION
Added support for `multipart/form-data` request body content. The support is a thin layer over the client-specific implementations which means that, for now at least, the core Java implementation does not support mutlipart requests.

There is some transitional work in here pending more detailed refactoring of the parsers and encoders.

This fixes #1 