### PR TITLE
Fixes nasty bug in UriKey.equals()

### DIFF
--- a/http-builder-ng-core/src/main/java/groovyx/net/http/NonBlockingCookieStore.java
+++ b/http-builder-ng-core/src/main/java/groovyx/net/http/NonBlockingCookieStore.java
@@ -167,7 +167,12 @@ class NonBlockingCookieStore implements CookieStore {
             }
 
             final UriKey rhs = (UriKey) o;
-            return host.equals(rhs.host) && name.equals(rhs.host);
+            return host.equals(rhs.host) && name.equals(rhs.name);
+        }
+
+        @Override
+        public String toString() {
+            return String.format("UriKey(name: %s, host: %s)", name, host);
         }
     }
 
@@ -221,6 +226,11 @@ class NonBlockingCookieStore implements CookieStore {
         @Override
         public int hashCode() {
             return 37 * (37 * name.hashCode() + domain.hashCode()) + (path == null ? 0 : path.hashCode());
+        }
+
+        @Override
+        public String toString() {
+            return String.format("DomainKey(name: %s, domain: %s, path: %s", name, domain, path);
         }
     }
 


### PR DESCRIPTION
@cjstehno Please take a look and approve/merge this pull request. This is a trivial bug fix but one that makes a huge impact. The bad equals() method oddly enough doesn't make any test fail, it just makes things really slow.

We noticed this when putting a client under heavy load at work today. Before the bug fix we get about 1,250 updates/second in the NonBlockingCookieStore. After the fix it goes to 3.15 million/second. I'm guessing it also causes memory problems as the ConcurrentHashMap creates huge linked lists to track all of the "different" cookies.

Since the impact is huge and the fix is simple, let's get a build out ASAP.