### PR TITLE
Direct Client Access and Custom Configuration

### DIFF
--- a/http-builder-ng-apache/src/main/java/groovyx/net/http/ApacheHttpBuilder.java
+++ b/http-builder-ng-apache/src/main/java/groovyx/net/http/ApacheHttpBuilder.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2017 HttpBuilder-NG Project
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/http-builder-ng-apache/src/test/groovy/groovyx/net/http/ApacheHttpBuilderSpec.groovy
+++ b/http-builder-ng-apache/src/test/groovy/groovyx/net/http/ApacheHttpBuilderSpec.groovy
@@ -16,6 +16,9 @@
 package groovyx.net.http
 
 import com.stehno.ersatz.ErsatzServer
+import org.apache.http.client.HttpClient
+import org.apache.http.client.config.RequestConfig
+import org.apache.http.impl.client.HttpClientBuilder
 import spock.lang.AutoCleanup
 import spock.lang.Specification
 
@@ -42,5 +45,36 @@ class ApacheHttpBuilderSpec extends Specification {
 
         and:
         http instanceof ApacheHttpBuilder
+    }
+
+    def 'access to client implementation'() {
+        setup:
+        HttpBuilder http = ApacheHttpBuilder.configure {
+            request.uri = "${ersatzServer.httpUrl}/foo"
+        }
+
+        expect:
+        http.clientImplementation instanceof HttpClient
+    }
+
+    def 'client customization'() {
+        setup:
+        HttpBuilder http = ApacheHttpBuilder.configure {
+            client.customizeClient { HttpClientBuilder builder ->
+                RequestConfig.Builder requestBuilder = RequestConfig.custom()
+                requestBuilder.connectTimeout = 1234567
+                requestBuilder.connectionRequestTimeout = 98765
+
+                builder.defaultRequestConfig = requestBuilder.build()
+            }
+            request.uri = "${ersatzServer.httpUrl}/foo"
+        }
+
+        when:
+        HttpClient client = http.clientImplementation
+
+        then:
+        client.defaultConfig.connectTimeout == 1234567
+        client.defaultConfig.connectionRequestTimeout == 98765
     }
 }

--- a/http-builder-ng-apache/src/test/groovy/groovyx/net/http/ApacheHttpBuilderSpec.groovy
+++ b/http-builder-ng-apache/src/test/groovy/groovyx/net/http/ApacheHttpBuilderSpec.groovy
@@ -60,7 +60,7 @@ class ApacheHttpBuilderSpec extends Specification {
     def 'client customization'() {
         setup:
         HttpBuilder http = ApacheHttpBuilder.configure {
-            client.customizeClient { HttpClientBuilder builder ->
+            client.clientCustomizer { HttpClientBuilder builder ->
                 RequestConfig.Builder requestBuilder = RequestConfig.custom()
                 requestBuilder.connectTimeout = 1234567
                 requestBuilder.connectionRequestTimeout = 98765

--- a/http-builder-ng-core/src/main/java/groovyx/net/http/HttpBuilder.java
+++ b/http-builder-ng-core/src/main/java/groovyx/net/http/HttpBuilder.java
@@ -1758,7 +1758,7 @@ public abstract class HttpBuilder implements Closeable {
     /**
      * Used to retrieve the instance of the internal client implementation. All client configuration will have been performed by the time this
      * method is accessible. If additional configuration is desired and not supported by HttpBuilder-NG directly, you should use the
-     * `HttpObjectConfig::Client::customizeClient(Consumer<Object>)` method.
+     * `HttpObjectConfig::Client::clientCustomizer(Consumer<Object>)` method.
      *
      * This functionality is optional and client-implementation-dependent. If access to the internal client is not supported, an
      * {@link UnsupportedOperationException} will be thrown.

--- a/http-builder-ng-core/src/main/java/groovyx/net/http/HttpBuilder.java
+++ b/http-builder-ng-core/src/main/java/groovyx/net/http/HttpBuilder.java
@@ -1755,6 +1755,18 @@ public abstract class HttpBuilder implements Closeable {
         return CompletableFuture.supplyAsync(() -> patch(type, configuration), getExecutor());
     }
 
+    /**
+     * Used to retrieve the instance of the internal client implementation. All client configuration will have been performed by the time this
+     * method is accessible. If additional configuration is desired and not supported by HttpBuilder-NG directly, you should use the
+     * `HttpObjectConfig::Client::customizeClient(Consumer<Object>)` method.
+     *
+     * This functionality is optional and client-implementation-dependent. If access to the internal client is not supported, an
+     * {@link UnsupportedOperationException} will be thrown.
+     *
+     * @return a reference to the internal client implementation used (or null if not supported)
+     */
+    public abstract Object getClientImplementation();
+
     protected abstract Object doGet(final ChainedHttpConfig config);
 
     protected abstract Object doHead(final ChainedHttpConfig config);

--- a/http-builder-ng-core/src/main/java/groovyx/net/http/HttpObjectConfig.java
+++ b/http-builder-ng-core/src/main/java/groovyx/net/http/HttpObjectConfig.java
@@ -15,15 +15,14 @@
  */
 package groovyx.net.http;
 
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
 import java.io.File;
-import java.net.CookieStore;
 import java.util.EnumMap;
 import java.util.concurrent.Executor;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.SSLContext;
 
 /**
  * Extension of the {@link HttpConfig} interface, which provides additional client-level configuration options. These options should be configured in
@@ -211,7 +210,7 @@ public interface HttpObjectConfig extends HttpConfig {
          *
          * This operation is optional. If a client-implementation does not support it, an {@link UnsupportedOperationException} will be thrown.
          */
-        void customizeClient(Consumer<Object> customizer);
+        void clientCustomizer(Consumer<Object> customizer);
 
         /**
          * Used to retrieve the configured client implementation customizer `Consumer`, if there is one.

--- a/http-builder-ng-core/src/main/java/groovyx/net/http/HttpObjectConfig.java
+++ b/http-builder-ng-core/src/main/java/groovyx/net/http/HttpObjectConfig.java
@@ -20,6 +20,7 @@ import java.net.CookieStore;
 import java.util.EnumMap;
 import java.util.concurrent.Executor;
 import java.util.function.BiFunction;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
@@ -187,7 +188,7 @@ public interface HttpObjectConfig extends HttpConfig {
         /**
          * Used to enable or disable cookies.
          *
-         * @param version true if cookies are enabled, false if not enabled.
+         * @param val true if cookies are enabled, false if not enabled.
          */
         void setCookiesEnabled(boolean val);
 
@@ -197,6 +198,27 @@ public interface HttpObjectConfig extends HttpConfig {
          * @return true if cookies are enabled, false if not
          */
         boolean getCookiesEnabled();
+
+        /**
+         * A `Consumer<Object>` may be provided, which will have the internal client implementation reference passed into it to allow further
+         * client configuration beyond what it supported directly by HttpBuilder-NG. The `Object` passed in will be an instance of the internal client
+         * builder type, not necessarily the client itself.
+         *
+         * This configuration method should _only_ be used when the desire configuration is _not_ available directly through the `HttpBuilder`
+         * configuration interfaces. Configuring in this manner may override helpful configuration already applied by the library.
+         *
+         * Note that a Groovy closure may be used to replace the `Consumer` with no modification of functionality.
+         *
+         * This operation is optional. If a client-implementation does not support it, an {@link UnsupportedOperationException} will be thrown.
+         */
+        void customizeClient(Consumer<Object> customizer);
+
+        /**
+         * Used to retrieve the configured client implementation customizer `Consumer`, if there is one.
+         *
+         * @return the configured client customizer
+         */
+        Consumer<Object> getClientCustomizer();
     }
 
     ChainedHttpConfig getChainedConfig();

--- a/http-builder-ng-core/src/main/java/groovyx/net/http/HttpObjectConfigImpl.java
+++ b/http-builder-ng-core/src/main/java/groovyx/net/http/HttpObjectConfigImpl.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.util.EnumMap;
 import java.util.concurrent.Executor;
 import java.util.function.BiFunction;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 import static groovyx.net.http.HttpConfigs.basic;
@@ -128,6 +129,7 @@ public class HttpObjectConfigImpl implements HttpObjectConfig {
         private boolean cookiesEnabled = true;
         private int cookieVersion = 0;
         private File cookieFolder;
+        private Consumer<Object> clientCustomizer;
 
         @Override
         public void setCookieVersion(int version) {
@@ -157,6 +159,16 @@ public class HttpObjectConfigImpl implements HttpObjectConfig {
         @Override
         public void setCookiesEnabled(final boolean val) {
             cookiesEnabled = val;
+        }
+
+        @Override
+        public void customizeClient(final Consumer<Object> customizer) {
+            this.clientCustomizer = customizer;
+        }
+
+        @Override
+        public Consumer<Object> getClientCustomizer() {
+            return clientCustomizer;
         }
     }
 

--- a/http-builder-ng-core/src/main/java/groovyx/net/http/HttpObjectConfigImpl.java
+++ b/http-builder-ng-core/src/main/java/groovyx/net/http/HttpObjectConfigImpl.java
@@ -162,7 +162,7 @@ public class HttpObjectConfigImpl implements HttpObjectConfig {
         }
 
         @Override
-        public void customizeClient(final Consumer<Object> customizer) {
+        public void clientCustomizer(final Consumer<Object> customizer) {
             this.clientCustomizer = customizer;
         }
 

--- a/http-builder-ng-core/src/main/java/groovyx/net/http/JavaHttpBuilder.java
+++ b/http-builder-ng-core/src/main/java/groovyx/net/http/JavaHttpBuilder.java
@@ -335,6 +335,18 @@ public class JavaHttpBuilder extends HttpBuilder {
         this.clientConfig = config.getClient();
         this.hostnameVerifier = config.getExecution().getHostnameVerifier();
         this.sslContext = config.getExecution().getSslContext();
+
+        if( clientConfig.getClientCustomizer() != null ){
+            throw new UnsupportedOperationException("Client implementation configuration is not available for the core Java implementation.");
+        }
+    }
+
+    /**
+     * The core Java client implementation does not support direct client access. This method will throw an {@link UnsupportedOperationException}.
+     */
+    @Override
+    public Object getClientImplementation() {
+        throw new UnsupportedOperationException("The core Java implementation does not support direct client access.");
     }
 
     protected ChainedHttpConfig getObjectConfig() {

--- a/http-builder-ng-core/src/main/java/groovyx/net/http/JavaHttpBuilder.java
+++ b/http-builder-ng-core/src/main/java/groovyx/net/http/JavaHttpBuilder.java
@@ -29,6 +29,7 @@ import java.net.*;
 import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
+import java.util.function.Consumer;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.InflaterInputStream;
 
@@ -36,7 +37,7 @@ import static groovyx.net.http.HttpBuilder.ResponseHandlerFunction.HANDLER_FUNCT
 
 /**
  * `HttpBuilder` implementation based on the {@link HttpURLConnection} class.
- * <p>
+ *
  * Generally, this class should not be used directly, the preferred method of instantiation is via the
  * `groovyx.net.http.HttpBuilder.configure(java.util.function.Function)` or
  * `groovyx.net.http.HttpBuilder.configure(java.util.function.Function, groovy.lang.Closure)` methods.
@@ -52,17 +53,22 @@ public class JavaHttpBuilder extends HttpBuilder {
         private final HttpURLConnection connection;
         private final ChainedHttpConfig requestConfig;
         private final URI theUri;
-        boolean failed = false;
 
-        public Action(final ChainedHttpConfig requestConfig, final String verb) throws IOException, URISyntaxException {
+        public Action(final Consumer<Object> clientCustomizer, final ChainedHttpConfig requestConfig, final String verb) throws IOException, URISyntaxException {
             this.requestConfig = requestConfig;
+
             final ChainedHttpConfig.ChainedRequest cr = requestConfig.getChainedRequest();
-            this.theUri = cr.getUri().toURI();
-            this.connection = (HttpURLConnection) theUri.toURL().openConnection();
-            this.connection.setRequestMethod(verb);
+            theUri = cr.getUri().toURI();
+
+            connection = (HttpURLConnection) theUri.toURL().openConnection();
+            connection.setRequestMethod(verb);
 
             if (cr.actualBody() != null) {
-                this.connection.setDoOutput(true);
+                connection.setDoOutput(true);
+            }
+
+            if( clientCustomizer != null ){
+                clientCustomizer.accept(connection);
             }
         }
 
@@ -322,12 +328,13 @@ public class JavaHttpBuilder extends HttpBuilder {
         Authenticator.setDefault(new ThreadLocalAuth());
     }
 
-    final private ChainedHttpConfig config;
-    final private Executor executor;
-    final private SSLContext sslContext;
-    final private HostnameVerifier hostnameVerifier;
-    final private HttpObjectConfig.Client clientConfig;
+    private final ChainedHttpConfig config;
+    private final Executor executor;
+    private final SSLContext sslContext;
+    private final HostnameVerifier hostnameVerifier;
+    private final HttpObjectConfig.Client clientConfig;
 
+    // TODO: this can probably be private or protected.
     public JavaHttpBuilder(final HttpObjectConfig config) {
         super(config);
         this.config = new HttpConfigs.ThreadSafeHttpConfig(config.getChainedConfig());
@@ -335,10 +342,6 @@ public class JavaHttpBuilder extends HttpBuilder {
         this.clientConfig = config.getClient();
         this.hostnameVerifier = config.getExecution().getHostnameVerifier();
         this.sslContext = config.getExecution().getSslContext();
-
-        if( clientConfig.getClientCustomizer() != null ){
-            throw new UnsupportedOperationException("Client implementation configuration is not available for the core Java implementation.");
-        }
     }
 
     /**
@@ -355,7 +358,7 @@ public class JavaHttpBuilder extends HttpBuilder {
 
     private Object createAndExecute(final ChainedHttpConfig config, final String verb) {
         try {
-            Action action = new Action(config, verb);
+            Action action = new Action(clientConfig.getClientCustomizer(), config, verb);
             return action.execute();
         } catch (Exception e) {
             return handleException(config.getChainedResponse(), e);

--- a/http-builder-ng-core/src/test/groovy/groovyx/net/http/JavaHttpBuilderSpec.groovy
+++ b/http-builder-ng-core/src/test/groovy/groovyx/net/http/JavaHttpBuilderSpec.groovy
@@ -20,6 +20,9 @@ import spock.lang.AutoCleanup
 import spock.lang.Specification
 
 import static com.stehno.ersatz.ContentType.TEXT_PLAIN
+import static java.util.concurrent.TimeUnit.MILLISECONDS
+import static java.util.concurrent.TimeUnit.MINUTES
+import static java.util.concurrent.TimeUnit.MINUTES
 
 class JavaHttpBuilderSpec extends Specification {
 
@@ -42,5 +45,31 @@ class JavaHttpBuilderSpec extends Specification {
 
         and:
         http instanceof JavaHttpBuilder
+    }
+
+    def 'access to client implementation unsupported'() {
+        setup:
+        HttpBuilder http = JavaHttpBuilder.configure {
+            request.uri = "${ersatzServer.httpUrl}/foo"
+        }
+
+        when:
+        http.clientImplementation
+
+        then:
+        thrown(UnsupportedOperationException)
+    }
+
+    def 'client customization unsupported'() {
+        when:
+        HttpBuilder http = JavaHttpBuilder.configure {
+            client.customizeClient { obj ->
+                // not going to get here
+            }
+            request.uri = "${ersatzServer.httpUrl}/foo"
+        }
+
+        then:
+        thrown(UnsupportedOperationException)
     }
 }

--- a/http-builder-ng-core/src/test/groovy/groovyx/net/http/JavaHttpBuilderSpec.groovy
+++ b/http-builder-ng-core/src/test/groovy/groovyx/net/http/JavaHttpBuilderSpec.groovy
@@ -20,9 +20,6 @@ import spock.lang.AutoCleanup
 import spock.lang.Specification
 
 import static com.stehno.ersatz.ContentType.TEXT_PLAIN
-import static java.util.concurrent.TimeUnit.MILLISECONDS
-import static java.util.concurrent.TimeUnit.MINUTES
-import static java.util.concurrent.TimeUnit.MINUTES
 
 class JavaHttpBuilderSpec extends Specification {
 
@@ -63,13 +60,13 @@ class JavaHttpBuilderSpec extends Specification {
     def 'client customization unsupported'() {
         when:
         HttpBuilder http = JavaHttpBuilder.configure {
-            client.customizeClient { obj ->
-                // not going to get here
+            client.clientCustomizer { HttpURLConnection connection ->
+                connection.connectTimeout = 8675309
             }
             request.uri = "${ersatzServer.httpUrl}/foo"
         }
 
-        then:
-        thrown(UnsupportedOperationException)
+        then: 'just ensure no failure'
+        http
     }
 }

--- a/http-builder-ng-okhttp/src/main/java/groovyx/net/http/OkHttpBuilder.java
+++ b/http-builder-ng-okhttp/src/main/java/groovyx/net/http/OkHttpBuilder.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2017 HttpBuilder-NG Project
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,12 +25,12 @@ import okhttp3.*;
 import okio.BufferedSink;
 
 import javax.net.ssl.SSLContext;
-import java.net.URISyntaxException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.util.LinkedHashMap;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -41,7 +41,6 @@ import java.util.function.Function;
 import static groovyx.net.http.FromServer.Header.keyValue;
 import static groovyx.net.http.HttpBuilder.ResponseHandlerFunction.HANDLER_FUNCTION;
 import static groovyx.net.http.HttpConfig.AuthType.DIGEST;
-import static java.util.stream.Collectors.toList;
 
 /**
  * `HttpBuilder` implementation based on the http://square.github.io/okhttp/[OkHttp] client library.
@@ -83,7 +82,21 @@ public class OkHttpBuilder extends HttpBuilder {
             );
         }
 
+        final Consumer<Object> clientCustomizer = clientConfig.getClientCustomizer();
+        if (clientCustomizer != null) {
+            clientCustomizer.accept(builder);
+        }
+
         this.client = builder.build();
+    }
+
+    /**
+     * Retrieves the internal client implementation as an {@link OkHttpClient} instance.
+     *
+     * @return the reference to the internal client implementation as an {@link OkHttpClient}
+     */
+    public Object getClientImplementation() {
+        return client;
     }
 
     /**
@@ -164,19 +177,19 @@ public class OkHttpBuilder extends HttpBuilder {
     @Override
     protected Object doPost(final ChainedHttpConfig chainedConfig) {
         return execute((url) -> new Request.Builder().post(resolveRequestBody(chainedConfig)).url(url),
-                       chainedConfig);
+            chainedConfig);
     }
 
     @Override
     protected Object doPut(final ChainedHttpConfig chainedConfig) {
         return execute((url) -> new Request.Builder().put(resolveRequestBody(chainedConfig)).url(url),
-                       chainedConfig);
+            chainedConfig);
     }
 
     @Override
     protected Object doPatch(final ChainedHttpConfig chainedConfig) {
         return execute((url) -> new Request.Builder().patch(resolveRequestBody(chainedConfig)).url(url),
-                chainedConfig);
+            chainedConfig);
     }
 
     @Override
@@ -229,25 +242,23 @@ public class OkHttpBuilder extends HttpBuilder {
         }
     }
 
-    private Object execute(final Function<HttpUrl,Request.Builder> makeBuilder, final ChainedHttpConfig chainedConfig) {
+    private Object execute(final Function<HttpUrl, Request.Builder> makeBuilder, final ChainedHttpConfig chainedConfig) {
         try {
             final ChainedHttpConfig.ChainedRequest cr = chainedConfig.getChainedRequest();
             final URI uri = cr.getUri().toURI();
             final HttpUrl httpUrl = HttpUrl.get(uri);
             final Request.Builder requestBuilder = makeBuilder.apply(httpUrl);
-            
+
             applyHeaders(requestBuilder, cr);
             applyAuth(requestBuilder, chainedConfig);
-            
-            try(Response response = client.newCall(requestBuilder.build()).execute()) {
+
+            try (Response response = client.newCall(requestBuilder.build()).execute()) {
                 return HANDLER_FUNCTION.apply(chainedConfig,
-                                              new OkHttpFromServer(chainedConfig.getChainedRequest().getUri().toURI(), response));
-            }
-            catch(IOException ioe) {
+                    new OkHttpFromServer(chainedConfig.getChainedRequest().getUri().toURI(), response));
+            } catch (IOException ioe) {
                 throw ioe; //re-throw, close has happened
             }
-        }
-        catch(Exception e) {
+        } catch (Exception e) {
             return handleException(chainedConfig.getChainedResponse(), e);
         }
     }
@@ -268,9 +279,9 @@ public class OkHttpBuilder extends HttpBuilder {
         private List<Header<?>> populateHeaders() {
             final Headers headers = response.headers();
             List<Header<?>> ret = new ArrayList<>();
-            for(String name : headers.names()) {
+            for (String name : headers.names()) {
                 List<String> values = headers.values(name);
-                for(String value : values) {
+                for (String value : values) {
                     ret.add(keyValue(name, value));
                 }
             }

--- a/http-builder-ng-okhttp/src/main/java/groovyx/net/http/OkHttpBuilder.java
+++ b/http-builder-ng-okhttp/src/main/java/groovyx/net/http/OkHttpBuilder.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2017 HttpBuilder-NG Project
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/http-builder-ng-okhttp/src/test/groovy/groovyx/net/http/OkHttpBuilderSpec.groovy
+++ b/http-builder-ng-okhttp/src/test/groovy/groovyx/net/http/OkHttpBuilderSpec.groovy
@@ -16,10 +16,13 @@
 package groovyx.net.http
 
 import com.stehno.ersatz.ErsatzServer
+import okhttp3.OkHttpClient
 import spock.lang.AutoCleanup
 import spock.lang.Specification
 
 import static com.stehno.ersatz.ContentType.TEXT_PLAIN
+import static java.util.concurrent.TimeUnit.MILLISECONDS
+import static java.util.concurrent.TimeUnit.MINUTES
 
 class OkHttpBuilderSpec extends Specification {
 
@@ -42,5 +45,31 @@ class OkHttpBuilderSpec extends Specification {
 
         and:
         http instanceof OkHttpBuilder
+    }
+
+    def 'access to client implementation'() {
+        setup:
+        HttpBuilder http = OkHttpBuilder.configure {
+            request.uri = "${ersatzServer.httpUrl}/foo"
+        }
+
+        expect:
+        http.clientImplementation instanceof OkHttpClient
+    }
+
+    def 'client customization'() {
+        setup:
+        HttpBuilder http = OkHttpBuilder.configure {
+            client.customizeClient { OkHttpClient.Builder builder ->
+                builder.connectTimeout(5, MINUTES)
+            }
+            request.uri = "${ersatzServer.httpUrl}/foo"
+        }
+
+        when:
+        OkHttpClient client = http.clientImplementation
+
+        then:
+        client.connectTimeoutMillis() == MILLISECONDS.convert(5, MINUTES)
     }
 }

--- a/http-builder-ng-okhttp/src/test/groovy/groovyx/net/http/OkHttpBuilderSpec.groovy
+++ b/http-builder-ng-okhttp/src/test/groovy/groovyx/net/http/OkHttpBuilderSpec.groovy
@@ -60,7 +60,7 @@ class OkHttpBuilderSpec extends Specification {
     def 'client customization'() {
         setup:
         HttpBuilder http = OkHttpBuilder.configure {
-            client.customizeClient { OkHttpClient.Builder builder ->
+            client.clientCustomizer { OkHttpClient.Builder builder ->
                 builder.connectTimeout(5, MINUTES)
             }
             request.uri = "${ersatzServer.httpUrl}/foo"

--- a/src/docs/asciidoc/configuration.adoc
+++ b/src/docs/asciidoc/configuration.adoc
@@ -452,8 +452,8 @@ options should be configured in the `HttpBuilder.configure` methods, rather than
 
 ==== Client
 
-The `getClient()` method of the `HttpObjectConfig` interface provides a means of applying client-specific configuration. Currently, there are only two
-supported configuration properties:
+The `getClient()` method of the `HttpObjectConfig` interface provides a means of applying client-specific configuration. The supported configuration
+options are as follows:
 
 * `cookieVersion` - the supported HTTP Cookie version used by the underlying clients. All three `HttpBuilder` implementations will support Cookies at
 version 0 by default, which is what the Java Servlet API accepts by default. This can be modified, but care must be taken to ensure that your server
@@ -461,14 +461,43 @@ supports and accepts the configured version.
 * `cookieFolder` - the location for storing cookies that will persist after your application terminates. If no folder is specified an in memory
 cookie store and no cookies will be persisted after your application terminates. If cookies are found here then the cookies will be loaded prior to
 sending any requests to remote servers.
+* `cookiesEnabled` - allows cookie support to be enabled and disabled in the client.
 
 [source,groovy]
 ----
 HttpBuilder.configure {
     client.cookieVersion = 0
     client.cookieFolder = new File('/tmp/cookies')
+    client.cookiesEnabled = true
 }
 ----
+
+There is also a provision for applying customizations directly on the underlying client implementation, at configuration-time. The
+`customizeClient(Consumer<Object>)` method is used to allow additional client-specific configuration on an instance. Each client implementation
+provides its own "builder" object as the `Object` parameter into the `Consumer`:
+
+* The `core` Java client does not support this customization, and will throw an `UnsupportedOperationException` if it is attempted.
+* The `apache` client will pass in the `org.apache.http.impl.client.HttpClientBuilder` instance.
+* The `okhttp` client will pass in the `okhttp.OkHttpClient.Builder` instance.
+
+When a builder instance is available, it will have already been configured with all of the HttpBuilder-provided configuration. The provided
+customization will be applied on top of the existing configuration.
+
+As an example, setting the connection timeout on the `okhttp` client would look like the following:
+
+[source,groovy]
+----
+HttpBuilder http = OkHttpBuilder.configure {
+    client.customizeClient { OkHttpClient.Builder builder ->
+        builder.connectTimeout(5, MINUTES)
+    }
+}
+----
+
+Notice, that a Groovy `Closure` works as well as a Java `Consumer`.
+
+WARNING: This configuration method is considered a last resort and should only be used in cases where the configuration is needed and not available
+through the HttpBuilder interfaces.
 
 ==== Execution
 
@@ -586,6 +615,9 @@ HttpBuilder.configure({ c -> new ApacheHttpBuilder(c) })
 
 Using the `ApacheHttpBuilder` requires the `http-builder-ng-apache` dependency to be added to your project. The third client implementation,
 `OkHttpBuilder` can be specified in the same manner (requiring the `http-builder-ng-okhttp` dependency).
+
+A method is provided to access the underlying HTTP client implementation, the `getClientImplementation()` method. This will return a reference to the
+underlying configured client instance. Support for this method is optional, see the JavaDocs for the specific implementation for more details.
 
 === Request-Related
 

--- a/src/docs/asciidoc/configuration.adoc
+++ b/src/docs/asciidoc/configuration.adoc
@@ -264,7 +264,7 @@ called, it is executed and its return value is used as the return value for the 
 HttpBuilder.configure {
     request.uri = 'http://localhost:8181'
 }.head {
-    reponse.when(200){ FromServer fs ->
+    response.when(200){ FromServer fs ->
         'ok'
     }
 }
@@ -282,7 +282,7 @@ The other two status handlers are the `success` and `failure` methods:
 HttpBuilder.configure {
     request.uri = 'http://localhost:8181'
 }.head {
-    reponse.success { FromServer fs ->
+    response.success { FromServer fs ->
         'ok'
     }
 }
@@ -473,10 +473,10 @@ HttpBuilder.configure {
 ----
 
 There is also a provision for applying customizations directly on the underlying client implementation, at configuration-time. The
-`customizeClient(Consumer<Object>)` method is used to allow additional client-specific configuration on an instance. Each client implementation
+`clientCustomizer(Consumer<Object>)` method is used to allow additional client-specific configuration on an instance. Each client implementation
 provides its own "builder" object as the `Object` parameter into the `Consumer`:
 
-* The `core` Java client does not support this customization, and will throw an `UnsupportedOperationException` if it is attempted.
+* The `core` client will pass in the `java.net.HttpURLConnection` instance.
 * The `apache` client will pass in the `org.apache.http.impl.client.HttpClientBuilder` instance.
 * The `okhttp` client will pass in the `okhttp.OkHttpClient.Builder` instance.
 
@@ -488,7 +488,7 @@ As an example, setting the connection timeout on the `okhttp` client would look 
 [source,groovy]
 ----
 HttpBuilder http = OkHttpBuilder.configure {
-    client.customizeClient { OkHttpClient.Builder builder ->
+    client.clientCustomizer { OkHttpClient.Builder builder ->
         builder.connectTimeout(5, MINUTES)
     }
 }

--- a/src/docs/asciidoc/examples.adoc
+++ b/src/docs/asciidoc/examples.adoc
@@ -176,3 +176,40 @@ Map, from which we can extract the data we sent.
 
 Note that the `NativeHandlers.Encoders.&form` encoder is used to convert the provided map data into the encoded message
 before sending it to the server.
+
+=== Configuring Timeout
+
+You can provide additional configuration not directly supported by `HttpBuilder`, such as connection timeout, using the
+`customizeClient(Consumer<Object>)` method (supported by the `apache` and `okhttp` client implementations):
+
+For the `apache` client:
+
+[source,groovy]
+----
+HttpBuilder http = ApacheHttpBuilder.configure {
+    client.customizeClient { HttpClientBuilder builder ->
+        RequestConfig.Builder requestBuilder = RequestConfig.custom()
+        requestBuilder.connectTimeout = 1234567
+        requestBuilder.connectionRequestTimeout = 98765
+
+        builder.defaultRequestConfig = requestBuilder.build()
+    }
+
+    // other config...
+}
+----
+
+and for the `okhttp` client:
+
+[source,groovy]
+----
+HttpBuilder http = OkHttpBuilder.configure {
+    client.customizeClient { OkHttpClient.Builder builder ->
+        builder.connectTimeout(5, MINUTES)
+    }
+
+    // other config...
+}
+----
+
+This additional custom configuration must be applied with care, as it is possible to undo the configuration provided by the `HttpBuilder` library.

--- a/src/docs/asciidoc/examples.adoc
+++ b/src/docs/asciidoc/examples.adoc
@@ -180,14 +180,14 @@ before sending it to the server.
 === Configuring Timeout
 
 You can provide additional configuration not directly supported by `HttpBuilder`, such as connection timeout, using the
-`customizeClient(Consumer<Object>)` method (supported by the `apache` and `okhttp` client implementations):
+`clientCustomizer(Consumer<Object>)` method (supported by all three client implementations):
 
 For the `apache` client:
 
 [source,groovy]
 ----
 HttpBuilder http = ApacheHttpBuilder.configure {
-    client.customizeClient { HttpClientBuilder builder ->
+    client.clientCustomizer { HttpClientBuilder builder ->
         RequestConfig.Builder requestBuilder = RequestConfig.custom()
         requestBuilder.connectTimeout = 1234567
         requestBuilder.connectionRequestTimeout = 98765
@@ -204,8 +204,21 @@ and for the `okhttp` client:
 [source,groovy]
 ----
 HttpBuilder http = OkHttpBuilder.configure {
-    client.customizeClient { OkHttpClient.Builder builder ->
+    client.clientCustomizer { OkHttpClient.Builder builder ->
         builder.connectTimeout(5, MINUTES)
+    }
+
+    // other config...
+}
+----
+
+and lastly, for the `core` client:
+
+[source,groovy]
+----
+HttpBuilder http = OkHttpBuilder.configure {
+    client.clientCustomizer { HttpURLConnection conn ->
+        connection.connectTimeout = 8675309
     }
 
     // other config...

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,6 +1,6 @@
 = HttpBuilder-NG User Guide
 David Clark & Christopher J. Stehno
-v0.16.1, April 2017
+v0.16.1, June 2017
 :toc: left
 :toclevels: 4
 

--- a/src/site/index.html
+++ b/src/site/index.html
@@ -80,6 +80,7 @@
     <li>Content compression</li>
     <li>Multipart request/response support</li>
     <li>BASIC and DIGEST authentication support</li>
+    <li>Support for client-implementation specific configuration.</li>
 </ul>
 
 <h2>Artifacts</h2>


### PR DESCRIPTION
#140: Provide ability to access/configure underlying client
#131: Document CookieStore
#141: Allow setting timeout on connection

Added support for accessing underlying client, providing additional custom configurations on the client, along with documentation about using it and the configuration itself.

@dwclark the main reason I'd like your input on this is due to the exposing of the underlying client implementations. I have had a few asks for config properties we dont support (and probably shouldn't) - this will take care of that.