### PR TITLE
[FIX-DOC] Renamed variable to 'connection'

### DIFF
--- a/src/docs/asciidoc/examples.adoc
+++ b/src/docs/asciidoc/examples.adoc
@@ -235,7 +235,7 @@ and lastly, for the `core` client:
 [source,groovy]
 ----
 HttpBuilder http = OkHttpBuilder.configure {
-    client.clientCustomizer { HttpURLConnection conn ->
+    client.clientCustomizer { HttpURLConnection connection ->
         connection.connectTimeout = 8675309
     }
 


### PR DESCRIPTION
The variable name was wrong so the example was not working out of the box