### PR TITLE
WIP: Copy client

### DIFF
--- a/http-builder-ng-apache/src/main/java/groovyx/net/http/ApacheHttpBuilder.java
+++ b/http-builder-ng-apache/src/main/java/groovyx/net/http/ApacheHttpBuilder.java
@@ -384,6 +384,11 @@ public class ApacheHttpBuilder extends HttpBuilder {
         this.client = myBuilder.build();
     }
 
+    @Override
+    protected Function<HttpObjectConfig, ? extends HttpBuilder> getFactory() {
+        return apacheFactory;
+    }
+
     /**
      * Retrieves the internal client implementation as an {@link HttpClient} instance.
      *

--- a/http-builder-ng-apache/src/main/java/groovyx/net/http/ApacheHttpBuilder.java
+++ b/http-builder-ng-apache/src/main/java/groovyx/net/http/ApacheHttpBuilder.java
@@ -322,7 +322,6 @@ public class ApacheHttpBuilder extends HttpBuilder {
     }
 
     final private CloseableHttpClient client;
-    final private ChainedHttpConfig config;
     final private Executor executor;
     final private HttpObjectConfig.Client clientConfig;
     final private ProxyInfo proxyInfo;
@@ -337,7 +336,6 @@ public class ApacheHttpBuilder extends HttpBuilder {
         super(config);
 
         this.proxyInfo = config.getExecution().getProxyInfo();
-        this.config = new HttpConfigs.ThreadSafeHttpConfig(config.getChainedConfig());
         this.executor = config.getExecution().getExecutor();
         this.clientConfig = config.getClient();
 
@@ -393,10 +391,6 @@ public class ApacheHttpBuilder extends HttpBuilder {
      */
     public Object getClientImplementation() {
         return client;
-    }
-
-    protected ChainedHttpConfig getObjectConfig() {
-        return config;
     }
 
     public Executor getExecutor() {

--- a/http-builder-ng-core/src/main/java/groovyx/net/http/HttpBuilder.java
+++ b/http-builder-ng-core/src/main/java/groovyx/net/http/HttpBuilder.java
@@ -240,8 +240,10 @@ public abstract class HttpBuilder implements Closeable {
 
     private final EnumMap<HttpVerb, BiFunction<ChainedHttpConfig, Function<ChainedHttpConfig, Object>, Object>> interceptors;
     private final CookieManager cookieManager;
-    
+    private final ChainedHttpConfig config;
+
     protected HttpBuilder(final HttpObjectConfig objectConfig) {
+        this.config = new HttpConfigs.ThreadSafeHttpConfig(objectConfig.getChainedConfig());
         this.interceptors = new EnumMap<>(objectConfig.getExecution().getInterceptors());
         this.cookieManager = new CookieManager(makeCookieStore(objectConfig), CookiePolicy.ACCEPT_ALL);
     }
@@ -1779,7 +1781,9 @@ public abstract class HttpBuilder implements Closeable {
 
     protected abstract Object doPatch(final ChainedHttpConfig config);
 
-    protected abstract ChainedHttpConfig getObjectConfig();
+    protected ChainedHttpConfig getObjectConfig() {
+        return config;
+    }
 
     public abstract Executor getExecutor();
 

--- a/http-builder-ng-core/src/main/java/groovyx/net/http/HttpBuilder.java
+++ b/http-builder-ng-core/src/main/java/groovyx/net/http/HttpBuilder.java
@@ -321,6 +321,28 @@ public abstract class HttpBuilder implements Closeable {
     }
 
     /**
+     * Create a copy of an existing HttpBuilder, maybe overriding some settings.
+     */
+    public HttpBuilder copy(@DelegatesTo(HttpObjectConfig.class) final Closure closure) {
+        HttpObjectConfig impl = new HttpObjectConfigImpl();
+        closure.setDelegate(impl);
+        closure.setResolveStrategy(Closure.DELEGATE_FIRST);
+        closure.call();
+        return getFactory().apply(impl);
+    }
+
+    /**
+     * Create a copy of an existing HttpBuilder, maybe overriding some settings.
+     */
+    public HttpBuilder copy(final Consumer<HttpObjectConfig> configuration) {
+        HttpObjectConfig impl = new HttpObjectConfigImpl();
+        configuration.accept(impl);
+        return getFactory().apply(impl);
+    }
+
+    protected abstract Function<HttpObjectConfig, ? extends HttpBuilder> getFactory();
+
+    /**
      * Executes a GET request on the configured URI. The `request.uri` property should be configured in the global client configuration in order to
      * have a target for the request.
      *

--- a/http-builder-ng-core/src/main/java/groovyx/net/http/JavaHttpBuilder.java
+++ b/http-builder-ng-core/src/main/java/groovyx/net/http/JavaHttpBuilder.java
@@ -333,7 +333,6 @@ public class JavaHttpBuilder extends HttpBuilder {
         Authenticator.setDefault(new ThreadLocalAuth());
     }
 
-    private final ChainedHttpConfig config;
     private final Executor executor;
     private final SSLContext sslContext;
     private final ProxyInfo proxyInfo;
@@ -343,7 +342,6 @@ public class JavaHttpBuilder extends HttpBuilder {
     // TODO: this can probably be private or protected.
     public JavaHttpBuilder(final HttpObjectConfig config) {
         super(config);
-        this.config = new HttpConfigs.ThreadSafeHttpConfig(config.getChainedConfig());
         this.executor = config.getExecution().getExecutor();
         this.clientConfig = config.getClient();
         this.hostnameVerifier = config.getExecution().getHostnameVerifier();
@@ -357,10 +355,6 @@ public class JavaHttpBuilder extends HttpBuilder {
     @Override
     public Object getClientImplementation() {
         throw new UnsupportedOperationException("The core Java implementation does not support direct client access.");
-    }
-
-    protected ChainedHttpConfig getObjectConfig() {
-        return config;
     }
 
     private Object createAndExecute(final ChainedHttpConfig config, final String verb) {

--- a/http-builder-ng-core/src/main/java/groovyx/net/http/JavaHttpBuilder.java
+++ b/http-builder-ng-core/src/main/java/groovyx/net/http/JavaHttpBuilder.java
@@ -30,6 +30,7 @@ import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.InflaterInputStream;
 
@@ -347,6 +348,11 @@ public class JavaHttpBuilder extends HttpBuilder {
         this.hostnameVerifier = config.getExecution().getHostnameVerifier();
         this.sslContext = config.getExecution().getSslContext();
         this.proxyInfo = config.getExecution().getProxyInfo();
+    }
+
+    @Override
+    protected Function<HttpObjectConfig, ? extends HttpBuilder> getFactory() {
+        return JavaHttpBuilder::new;
     }
 
     /**

--- a/http-builder-ng-core/src/test/groovy/groovyx/net/http/JavaHttpBuilderSpec.groovy
+++ b/http-builder-ng-core/src/test/groovy/groovyx/net/http/JavaHttpBuilderSpec.groovy
@@ -28,6 +28,7 @@ class JavaHttpBuilderSpec extends Specification {
         autoStart()
         expectations {
             get('/foo').responds().content('ok', TEXT_PLAIN)
+            get('/bar').responds().content('ok2', TEXT_PLAIN)
         }
     })
 
@@ -68,5 +69,19 @@ class JavaHttpBuilderSpec extends Specification {
 
         then: 'just ensure no failure'
         http
+    }
+
+    def 'copying the client'() {
+        when:
+        HttpBuilder http = JavaHttpBuilder.configure {
+            request.uri = "${ersatzServer.httpUrl}/foo"
+        }
+        HttpBuilder http2 = http.copy {
+            request.uri = "${ersatzServer.httpUrl}/bar"
+        }
+
+        then:
+            http.get() == 'ok'
+            http2.get() == 'ok2'
     }
 }

--- a/http-builder-ng-okhttp/src/main/java/groovyx/net/http/OkHttpBuilder.java
+++ b/http-builder-ng-okhttp/src/main/java/groovyx/net/http/OkHttpBuilder.java
@@ -52,7 +52,6 @@ import static groovyx.net.http.HttpConfig.AuthType.DIGEST;
 public class OkHttpBuilder extends HttpBuilder {
 
     private static final Function<HttpObjectConfig, ? extends HttpBuilder> okFactory = OkHttpBuilder::new;
-    private final ChainedHttpConfig config;
     private final HttpObjectConfig.Client clientConfig;
     private final Executor executor;
     private final OkHttpClient client;
@@ -60,7 +59,6 @@ public class OkHttpBuilder extends HttpBuilder {
     protected OkHttpBuilder(final HttpObjectConfig config) {
         super(config);
 
-        this.config = new HttpConfigs.ThreadSafeHttpConfig(config.getChainedConfig());
         this.clientConfig = config.getClient();
         this.executor = config.getExecution().getExecutor();
 
@@ -162,11 +160,6 @@ public class OkHttpBuilder extends HttpBuilder {
      */
     public static HttpBuilder configure(final Consumer<HttpObjectConfig> configuration) {
         return configure(okFactory, configuration);
-    }
-
-    @Override
-    protected ChainedHttpConfig getObjectConfig() {
-        return config;
     }
 
     @Override

--- a/http-builder-ng-okhttp/src/main/java/groovyx/net/http/OkHttpBuilder.java
+++ b/http-builder-ng-okhttp/src/main/java/groovyx/net/http/OkHttpBuilder.java
@@ -93,7 +93,12 @@ public class OkHttpBuilder extends HttpBuilder {
 
         this.client = builder.build();
     }
-    
+
+    @Override
+    protected Function<HttpObjectConfig, ? extends HttpBuilder> getFactory() {
+        return okFactory;
+    }
+
     private boolean usesProxy(final ProxyInfo pinfo) {
         return pinfo != null && pinfo.getProxy().type() != Proxy.Type.DIRECT;
     }


### PR DESCRIPTION
First stab at some methods to allow copying an existing HttpBuilder.

Ideas:
- This chains the config of the new client to the config of the old client. I think this is a valid strategy, but not 100% sure
- This adds a new method to just return the concrete builder that was used to build the instance. There is probably a more elegant way to do this...

(Merging this fixes #154)