### PR TITLE
RE: Problem encoding "/" as %2F for path elements in request URI

### DIFF
--- a/http-builder-ng-core/src/main/java/groovyx/net/http/UriBuilder.java
+++ b/http-builder-ng-core/src/main/java/groovyx/net/http/UriBuilder.java
@@ -208,6 +208,19 @@ public abstract class UriBuilder {
 //        return new URI(scheme, userInfo, host, (port == null ? -1 : port), ((path == null) ? null : path.toString()), query, fragment);
     }
 
+    /**
+     * Given the individual `URI` elements, construct a literal string representation of the `URI` that can be used to
+     * call {@link java.net.URI#URI(String)}.
+     *
+     * @param scheme
+     * @param userInfo
+     * @param host
+     * @param port
+     * @param path
+     * @param query
+     * @param fragment
+     * @return
+     */
     private String getURIAsString(String scheme, String userInfo, String host, Integer port, String path, String query, String fragment ) {
 
         String portStr = port == null ? "" : port.toString();

--- a/http-builder-ng-core/src/main/java/groovyx/net/http/UriBuilder.java
+++ b/http-builder-ng-core/src/main/java/groovyx/net/http/UriBuilder.java
@@ -222,6 +222,11 @@ public abstract class UriBuilder {
      * @return
      */
     private String getURIAsString(String scheme, String userInfo, String host, Integer port, String path, String query, String fragment ) {
+        if (scheme == null) {
+            scheme = "";
+        } else if (!scheme.endsWith("://")) {
+            scheme += "://";
+        }
 
         String portStr = port == null ? "" : port.toString();
 
@@ -231,13 +236,17 @@ public abstract class UriBuilder {
             userInfo += "@";
         }
 
+        if (host == null) {
+            host = "";
+        }
+
         if (!portStr.isEmpty()) {
             portStr = ":" + portStr;
         }
 
         if (path == null) {
             path = "";
-        } else if (!path.startsWith("/")) {
+        } else if (!path.startsWith("/") && !path.isEmpty()) {
             path = "/" + path;
         }
 
@@ -250,10 +259,10 @@ public abstract class UriBuilder {
         if (fragment == null) {
             fragment = "";
         } else if ( !fragment.startsWith("#")) {
-            fragment = "?" + fragment;
+            fragment = "#" + fragment;
         }
 
-        String uri = String.format("%s://%s%s%s%s%s",
+        String uri = String.format("%s%s%s%s%s%s%s",
                 scheme,
                 userInfo,
                 host,

--- a/http-builder-ng-core/src/main/java/groovyx/net/http/UriBuilder.java
+++ b/http-builder-ng-core/src/main/java/groovyx/net/http/UriBuilder.java
@@ -15,9 +15,6 @@
  */
 package groovyx.net.http;
 
-import groovy.lang.GString;
-import org.codehaus.groovy.runtime.GStringImpl;
-
 import java.io.IOException;
 import java.net.HttpCookie;
 import java.net.URI;
@@ -95,19 +92,11 @@ public abstract class UriBuilder {
     public abstract String getHost();
 
     /**
-     * Sets the path part of the URI.
-     *
-     * @param val the path part of the URI
-     * @return a reference to the builder
-     */
-    public abstract UriBuilder setPath(GString val);
-
-    /**
      * Retrieves the path part of the URI.
      *
      * @return the path part of the URI
      */
-    public abstract GString getPath();
+    public abstract String getPath();
 
     /**
      * Sets the query string part of the `URI` from the provided map. The query string key-value pairs will be generated from the key-value pairs
@@ -164,19 +153,30 @@ public abstract class UriBuilder {
      * @return a reference to the builder
      */
     public UriBuilder setPath(final String str) {
-        return setPath(new GStringImpl(EMPTY, new String[]{str}));
+        return setPath(str == null ? "" : str);
     }
 
     public URI forCookie(final HttpCookie cookie) throws URISyntaxException {
         final String scheme = traverse(this, UriBuilder::getParent, UriBuilder::getScheme, Traverser::notNull);
-        final Integer port = traverse(this, UriBuilder::getParent, UriBuilder::getPort, notValue(DEFAULT_PORT));
+        final String userInfo = null;
         final String host = traverse(this, UriBuilder::getParent, UriBuilder::getHost, Traverser::notNull);
+        final Integer port = traverse(this, UriBuilder::getParent, UriBuilder::getPort, notValue(DEFAULT_PORT));
         final String path = cookie.getPath();
         final String query = null;
         final String fragment = null;
-        final String userInfo = null;
 
-        return new URI(scheme, userInfo, host, (port == null ? -1 : port), path, query, fragment);
+        final String uri = getURIAsString(
+                scheme,
+                userInfo,
+                host,
+                port,
+                path,
+                query,
+                fragment
+        );
+
+        return new URI(uri);
+//        return new URI(scheme, userInfo, host, (port == null ? -1 : port), path, query, fragment);
     }
 
     /**
@@ -186,14 +186,71 @@ public abstract class UriBuilder {
      */
     public URI toURI() throws URISyntaxException {
         final String scheme = traverse(this, UriBuilder::getParent, UriBuilder::getScheme, Traverser::notNull);
-        final Integer port = traverse(this, UriBuilder::getParent, UriBuilder::getPort, notValue(DEFAULT_PORT));
+        final String userInfo = traverse(this, UriBuilder::getParent, UriBuilder::getUserInfo, Traverser::notNull);
         final String host = traverse(this, UriBuilder::getParent, UriBuilder::getHost, Traverser::notNull);
-        final GString path = traverse(this, UriBuilder::getParent, UriBuilder::getPath, Traverser::notNull);
+        final Integer port = traverse(this, UriBuilder::getParent, UriBuilder::getPort, notValue(DEFAULT_PORT));
+        final String path = traverse(this, UriBuilder::getParent, UriBuilder::getPath, Traverser::notNull);
         final String query = populateQueryString(traverse(this, UriBuilder::getParent, UriBuilder::getQuery, Traverser::nonEmptyMap));
         final String fragment = traverse(this, UriBuilder::getParent, UriBuilder::getFragment, Traverser::notNull);
-        final String userInfo = traverse(this, UriBuilder::getParent, UriBuilder::getUserInfo, Traverser::notNull);
-        
-        return new URI(scheme, userInfo, host, (port == null ? -1 : port), ((path == null) ? null : path.toString()), query, fragment);
+
+        // <scheme>://[<userInfo@]<host>:<port><path>?<query>#<fragment>
+        final String uri = getURIAsString(
+                scheme,
+                userInfo,
+                host,
+                port,
+                path,
+                query,
+                fragment
+        );
+
+        return new URI(uri);
+//        return new URI(scheme, userInfo, host, (port == null ? -1 : port), ((path == null) ? null : path.toString()), query, fragment);
+    }
+
+    private String getURIAsString(String scheme, String userInfo, String host, Integer port, String path, String query, String fragment ) {
+
+        String portStr = port == null ? "" : port.toString();
+
+        if (userInfo == null) {
+            userInfo = "";
+        } else if (!userInfo.endsWith("@")) {
+            userInfo += "@";
+        }
+
+        if (!portStr.isEmpty()) {
+            portStr = ":" + portStr;
+        }
+
+        if (path == null) {
+            path = "";
+        } else if (!path.startsWith("/")) {
+            path = "/" + path;
+        }
+
+        if (query == null) {
+            query = "";
+        } else if ( !query.startsWith("?")) {
+            query = "?" + query;
+        }
+
+        if (fragment == null) {
+            fragment = "";
+        } else if ( !fragment.startsWith("#")) {
+            fragment = "?" + fragment;
+        }
+
+        String uri = String.format("%s://%s%s%s%s%s",
+                scheme,
+                userInfo,
+                host,
+                portStr,
+                path,
+                query,
+                fragment
+        );
+
+        return uri;
     }
 
     private static final Object[] EMPTY = new Object[0];
@@ -222,18 +279,18 @@ public abstract class UriBuilder {
             setPort(uri.getPort());
             setHost(uri.getHost());
 
-            final String path = uri.getPath();
+            final String path = uri.getRawPath();
             if (path != null) {
-                setPath(new GStringImpl(EMPTY, new String[]{path}));
+                setPath(path);
             }
 
-            final String rawQuery = uri.getQuery();
+            final String rawQuery = uri.getRawQuery();
             if (rawQuery != null) {
                 setQuery(Form.decode(new StringBuilder(rawQuery), UTF_8));
             }
 
-            setFragment(uri.getFragment());
-            setUserInfo(uri.getUserInfo());
+            setFragment(uri.getRawFragment());
+            setUserInfo(uri.getRawUserInfo());
         }
         catch (IOException e) {
             //this seems o.k. to just convert to a runtime exception,
@@ -346,14 +403,14 @@ public abstract class UriBuilder {
             return host;
         }
 
-        private GString path;
+        private String path;
 
-        public UriBuilder setPath(GString val) {
+        public UriBuilder setPath(String val) {
             path = val;
             return this;
         }
 
-        public GString getPath() {
+        public String getPath() {
             return path;
         }
 
@@ -437,14 +494,14 @@ public abstract class UriBuilder {
             return host;
         }
 
-        private volatile GString path;
+        private volatile String path;
 
-        public UriBuilder setPath(GString val) {
+        public UriBuilder setPath(String val) {
             path = val;
             return this;
         }
 
-        public GString getPath() {
+        public String getPath() {
             return path;
         }
 

--- a/http-builder-ng-core/src/test/groovy/groovyx/net/http/UriBuilderSpec.groovy
+++ b/http-builder-ng-core/src/test/groovy/groovyx/net/http/UriBuilderSpec.groovy
@@ -137,6 +137,18 @@ class UriBuilderSpec extends Specification {
 
         then:
         builder.toURI() == 'http://localhost:1234/foo'.toURI()
+
+        when:
+        builder.path = '/foo%2Fbar'
+
+        then:
+        builder.toURI().toString() == 'http://localhost:1234/foo%2Fbar'
+
+        when:
+        builder.path = '/foo%2Fbar%25baz%26qux'
+
+        then:
+        builder.toURI() == 'http://localhost:1234/foo%2Fbar%25baz%26qux'.toURI()
     }
 
     def 'uri full specified with query string'() {


### PR DESCRIPTION
I think this is possibly close to a working solution.  Three main changes are in UriBuilder.java:

1.  I changed the 'path' type from GString to String.  I didn't understand why GString is used and I needed to check for formatting to manipulate the path value for #3 below.
2.  Changed populateFrom() to call the uri.getRawXXX() methods for path, query, fragment and userInfo.   That way if someone created a custom URI instance with embedded encoding, it should honor their formatting.
3.  **(THIS IS THE KEY CHANGE)**  Changed toURI() to create the URI using the single-argument constructor.  According to https://docs.oracle.com/javase/7/docs/api/java/net/URI.html :

> The single-argument constructor requires any illegal characters in its argument to be quoted and **preserves any escaped octets and other characters that are present.**
> 
> The multi-argument constructors quote illegal characters as required by the components in which they appear. **The percent character ('%') is always quoted by these constructors**. Any other characters are preserved.

From what I can determine, if you call the 'single-argument' constructor (e.g., `URI uri = new URI(myUriString);`), it will honor any escaped values.  If you use the 'multi-argument' constructor currently used by UriBuilder, it will escape anything that is invalid.  This explains why the '%2F' would become "%252F".  

This current attempt added the method getURIAsString() to manually build a String representation of the URI and use the single-argument constructor to create the URI instance.
