### PR TITLE
Fix for handling encoded parts of URI path

### DIFF
--- a/http-builder-ng-core/src/main/java/groovyx/net/http/HttpConfig.java
+++ b/http-builder-ng-core/src/main/java/groovyx/net/http/HttpConfig.java
@@ -275,6 +275,9 @@ public interface HttpConfig {
          */
         void setUri(String val);
 
+        // FIXME: document here and user guide
+        void setRaw(String val);
+
         /**
          * The `request.uri` is the URI of the HTTP endpoint for the request, specified as a `URI` in this case.
          *

--- a/http-builder-ng-core/src/main/java/groovyx/net/http/HttpConfig.java
+++ b/http-builder-ng-core/src/main/java/groovyx/net/http/HttpConfig.java
@@ -19,7 +19,6 @@ import groovy.lang.Closure;
 import groovyx.net.http.fn.ClosureBiFunction;
 import groovyx.net.http.fn.ClosureFunction;
 
-import java.net.UnknownHostException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -275,7 +274,13 @@ public interface HttpConfig {
          */
         void setUri(String val);
 
-        // FIXME: document here and user guide
+        /**
+         * The `request.raw` is the means of specifying a "raw" URI as the HTTP endpoint for the request, specified as a `String`. No encoding or decoding is performed on a "raw" URI. Any such
+         * encoding or decoding of URI content must be done in the provided string itself, as it will be used "as is" in the resulting URI. This functionality is useful in the case where
+         * there are encoded entities in the URI path, since the standard `uri` method will decode these on building the `URI`.
+         *
+         * @param val the raw URI string
+         */
         void setRaw(String val);
 
         /**

--- a/http-builder-ng-core/src/main/java/groovyx/net/http/HttpConfigs.java
+++ b/http-builder-ng-core/src/main/java/groovyx/net/http/HttpConfigs.java
@@ -15,19 +15,11 @@
  */
 package groovyx.net.http;
 
-import groovy.lang.GroovyShell;
-import groovy.transform.TypeChecked;
 import groovyx.net.http.optional.Csv;
 import groovyx.net.http.optional.Html;
-import org.codehaus.groovy.control.CompilerConfiguration;
-import org.codehaus.groovy.control.customizers.ASTTransformationCustomizer;
-import org.codehaus.groovy.control.customizers.ImportCustomizer;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.net.HttpCookie;
-import java.net.UnknownHostException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -36,7 +28,12 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.util.*;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -44,8 +41,15 @@ import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
-import static groovyx.net.http.ContentTypes.*;
-import static groovyx.net.http.ChainedHttpConfig.*;
+import static groovyx.net.http.ChainedHttpConfig.Auth;
+import static groovyx.net.http.ChainedHttpConfig.AuthType;
+import static groovyx.net.http.ChainedHttpConfig.ChainedRequest;
+import static groovyx.net.http.ChainedHttpConfig.ChainedResponse;
+import static groovyx.net.http.ContentTypes.BINARY;
+import static groovyx.net.http.ContentTypes.JSON;
+import static groovyx.net.http.ContentTypes.TEXT;
+import static groovyx.net.http.ContentTypes.URLENC;
+import static groovyx.net.http.ContentTypes.XML;
 import static groovyx.net.http.Safe.ifClassIsLoaded;
 import static groovyx.net.http.Safe.register;
 
@@ -56,7 +60,7 @@ public class HttpConfigs {
         private String password;
         private boolean preemptive;
         private AuthType authType;
-        
+
         public void basic(final String user, final String password, final boolean preemptive) {
             this.user = user;
             this.password = password;
@@ -87,7 +91,7 @@ public class HttpConfigs {
         volatile String password;
         volatile boolean preemptive;
         volatile AuthType authType;
-        
+
         public ThreadSafeAuth() { }
 
         public ThreadSafeAuth(final BasicAuth toCopy) {
@@ -96,7 +100,7 @@ public class HttpConfigs {
             this.preemptive = toCopy.preemptive;
             this.authType = toCopy.authType;
         }
-        
+
         public void basic(final String user, final String password, final boolean preemptive) {
             this.user = user;
             this.password = password;
@@ -137,13 +141,15 @@ public class HttpConfigs {
         public void setCharset(final String val) {
             setCharset(Charset.forName(val));
         }
-        
+
         public void setUri(final String val) {
             getUri().setFull(val);
         }
 
         public void setRaw(final String val){
-
+            UriBuilder uriBuilder = getUri();
+            uriBuilder.setUseRawValues(true);
+            uriBuilder.setFull(val);
         }
 
         public void setUri(final URI val) {
@@ -158,11 +164,11 @@ public class HttpConfigs {
             final BiConsumer<ChainedHttpConfig,ToServer> enc =  getEncoderMap().get(contentType);
             return enc != null ? enc : null;
         }
-        
+
         public void encoder(final String contentType, final BiConsumer<ChainedHttpConfig,ToServer> val) {
             getEncoderMap().put(contentType, val);
         }
-        
+
         public void encoder(final Iterable<String> contentTypes, final BiConsumer<ChainedHttpConfig,ToServer> val) {
             for(String contentType : contentTypes) {
                 encoder(contentType, val);
@@ -193,10 +199,10 @@ public class HttpConfigs {
             if(instant != null && now.isBefore(instant)) {
                 cookie.setMaxAge(instant.getEpochSecond() - now.getEpochSecond());
             }
-            
+
             getCookies().add(cookie);
         }
-        
+
         public void cookie(final String name, final String value, final Date date) {
             cookie(name, value, date == null ? (Instant) null : date.toInstant());
         }
@@ -215,7 +221,7 @@ public class HttpConfigs {
         private final Map<String,BiConsumer<ChainedHttpConfig,ToServer>> encoderMap = new LinkedHashMap<>();
         private BasicAuth auth = new BasicAuth();
         private List<HttpCookie> cookies = new ArrayList<>(1);
-        
+
         protected BasicRequest(ChainedRequest parent) {
             super(parent);
             this.uriBuilder = (parent == null) ? UriBuilder.basic(null) : UriBuilder.basic(parent.getUri());
@@ -228,11 +234,11 @@ public class HttpConfigs {
         public List<HttpCookie> getCookies() {
             return cookies;
         }
-        
+
         public String getContentType() {
             return contentType;
         }
-        
+
         public void setContentType(final String val) {
             this.contentType = val;
         }
@@ -244,19 +250,19 @@ public class HttpConfigs {
         public Charset getCharset() {
             return charset;
         }
-        
+
         public UriBuilder getUri() {
             return uriBuilder;
         }
-        
+
         public Map<String,String> getHeaders() {
             return headers;
         }
-        
+
         public Object getBody() {
             return body;
         }
-        
+
         public void setBody(Object val) {
             this.body = val;
         }
@@ -265,9 +271,9 @@ public class HttpConfigs {
             return auth;
         }
     }
-    
+
     public static class ThreadSafeRequest extends BaseRequest {
-        
+
         private volatile String contentType;
         private volatile Charset charset;
         private volatile UriBuilder uriBuilder;
@@ -276,7 +282,7 @@ public class HttpConfigs {
         private final ConcurrentMap<String,BiConsumer<ChainedHttpConfig,ToServer>> encoderMap = new ConcurrentHashMap<>();
         private final ThreadSafeAuth auth;
         private final List<HttpCookie> cookies = new CopyOnWriteArrayList<>();
-        
+
         public ThreadSafeRequest(final ChainedRequest parent) {
             super(parent);
             this.auth = new ThreadSafeAuth();
@@ -286,7 +292,7 @@ public class HttpConfigs {
         public List<HttpCookie> getCookies() {
             return cookies;
         }
-        
+
         public Map<String,BiConsumer<ChainedHttpConfig,ToServer>> getEncoderMap() {
             return encoderMap;
         }
@@ -294,7 +300,7 @@ public class HttpConfigs {
         public String getContentType() {
             return contentType;
         }
-        
+
         public void setContentType(final String val) {
             this.contentType = val;
         }
@@ -302,23 +308,23 @@ public class HttpConfigs {
         public Charset getCharset() {
             return charset;
         }
-        
+
         public void setCharset(final Charset val) {
             this.charset = val;
         }
-        
+
         public UriBuilder getUri() {
             return uriBuilder;
         }
-        
+
         public Map<String,String> getHeaders() {
             return headers;
         }
-        
+
         public Object getBody() {
             return body;
         }
-        
+
         public void setBody(Object val) {
             this.body = val;
         }
@@ -334,7 +340,7 @@ public class HttpConfigs {
         abstract protected BiFunction<FromServer, Object, ?> getSuccess();
         abstract protected BiFunction<FromServer, Object, ?> getFailure();
         abstract protected Map<String,BiFunction<ChainedHttpConfig,FromServer,Object>> getParserMap();
-        
+
         private final ChainedResponse parent;
 
         public ChainedResponse getParent() {
@@ -344,15 +350,15 @@ public class HttpConfigs {
         protected BaseResponse(final ChainedResponse parent) {
             this.parent = parent;
         }
-        
+
         public void when(String code, BiFunction<FromServer, Object, ?> closure) {
             when(Integer.valueOf(code), closure);
         }
-        
+
         public void when(Integer code, BiFunction<FromServer, Object, ?> closure) {
             getByCode().put(code, closure);
         }
-        
+
         public void when(final HttpConfig.Status status, final BiFunction<FromServer, Object, ?> closure) {
             if(status == HttpConfig.Status.SUCCESS) {
                 success(closure);
@@ -365,27 +371,27 @@ public class HttpConfigs {
             if(getByCode().containsKey(code)) {
                 return getByCode().get(code);
             }
-            
+
             if(code < 400 && getSuccess() != null) {
                 return getSuccess();
             }
-            
+
             if(code >= 400 && getFailure() != null) {
                 return getFailure();
             }
 
             return null;
         }
-        
+
         public BiFunction<ChainedHttpConfig,FromServer,Object> parser(final String contentType) {
             final BiFunction<ChainedHttpConfig,FromServer,Object> p = getParserMap().get(contentType);
             return p != null ? p : null;
         }
-        
+
         public void parser(final String contentType, BiFunction<ChainedHttpConfig,FromServer,Object> val) {
             getParserMap().put(contentType, val);
         }
-        
+
         public void parser(final Iterable<String> contentTypes, BiFunction<ChainedHttpConfig,FromServer,Object> val) {
             for(String contentType : contentTypes) {
                 parser(contentType, val);
@@ -403,15 +409,15 @@ public class HttpConfigs {
         private Function<Throwable,?> exceptionHandler;
         private final Map<String,BiFunction<ChainedHttpConfig,FromServer,Object>> parserMap = new LinkedHashMap<>();
         private Class<?> type = Object.class;
-        
+
         protected BasicResponse(final ChainedResponse parent) {
             super(parent);
         }
-        
+
         public Map<String,BiFunction<ChainedHttpConfig,FromServer,Object>> getParserMap() {
             return parserMap;
         }
-        
+
         protected Map<Integer,BiFunction<FromServer, Object, ?>> getByCode() {
             return byCode;
         }
@@ -419,7 +425,7 @@ public class HttpConfigs {
         protected BiFunction<FromServer, Object, ?> getSuccess() {
             return successHandler;
         }
-        
+
         protected BiFunction<FromServer, Object, ?> getFailure() {
             return failureHandler;
         }
@@ -465,7 +471,7 @@ public class HttpConfigs {
         protected Map<String,BiFunction<ChainedHttpConfig,FromServer,Object>> getParserMap() {
             return parserMap;
         }
-        
+
         protected Map<Integer,BiFunction<FromServer, Object, ?>> getByCode() {
             return byCode;
         }
@@ -473,7 +479,7 @@ public class HttpConfigs {
         protected BiFunction<FromServer, Object, ?> getSuccess() {
             return successHandler;
         }
-        
+
         protected BiFunction<FromServer, Object, ?> getFailure() {
             return failureHandler;
         }
@@ -525,7 +531,7 @@ public class HttpConfigs {
                     catch(IOException e) {
                         throw new TransportingException(e);
                     } });
-                    
+
             getRequest().encoder(URLENC, NativeHandlers.Encoders::form);
             getRequest().encoder(XML, NativeHandlers.Encoders::xml);
             getRequest().encoder(JSON, NativeHandlers.Encoders::json);
@@ -533,7 +539,7 @@ public class HttpConfigs {
             getResponse().success(NativeHandlers::success);
             getResponse().failure(NativeHandlers::failure);
             getResponse().exception(NativeHandlers::exception);
-                
+
             getResponse().parser(BINARY, NativeHandlers.Parsers::streamToBytes);
             getResponse().parser(TEXT, NativeHandlers.Parsers::textToString);
             getResponse().parser(URLENC, NativeHandlers.Parsers::form);
@@ -547,12 +553,12 @@ public class HttpConfigs {
             getContextMap().put(new AbstractMap.SimpleImmutableEntry<>(contentType, id), obj);
         }
     }
-    
+
     public static class ThreadSafeHttpConfig extends BaseHttpConfig {
         private final ThreadSafeRequest request;
         private final ThreadSafeResponse response;
         private final ConcurrentMap<Map.Entry<String,Object>,Object> contextMap = new ConcurrentHashMap<>();
-        
+
         public ThreadSafeHttpConfig(final ChainedHttpConfig parent) {
             super(parent);
             if(parent == null) {
@@ -590,7 +596,7 @@ public class HttpConfigs {
         private final BasicRequest request;
         private final BasicResponse response;
         private final Map<Map.Entry<String,Object>,Object> contextMap = new LinkedHashMap<>(1);
-        
+
         public BasicHttpConfig(final ChainedHttpConfig parent) {
             super(parent);
             if(parent == null) {
@@ -628,18 +634,18 @@ public class HttpConfigs {
 
     static {
         root = (ThreadSafeHttpConfig) new ThreadSafeHttpConfig(null).configure();
-        
+
         register(root, ifClassIsLoaded("org.cyberneko.html.parsers.SAXParser"),
                  "text/html", () -> NativeHandlers.Encoders::xml, Html.neckoParserSupplier);
-        
+
         register(root, ifClassIsLoaded("org.jsoup.Jsoup"),
                  "text/html", Html.jsoupEncoderSupplier, Html.jsoupParserSupplier);
-        
+
         if(register(root, ifClassIsLoaded("com.opencsv.CSVReader"),
                     "text/csv", Csv.encoderSupplier, Csv.parserSupplier)) {
             root.context("text/csv", Csv.Context.ID, Csv.Context.DEFAULT_CSV);
         }
-        
+
         if(register(root, ifClassIsLoaded("com.opencsv.CSVReader"),
                     "text/tab-separated-values", Csv.encoderSupplier, Csv.parserSupplier)) {
             root.context("text/tab-separated-values", Csv.Context.ID, Csv.Context.DEFAULT_TSV);

--- a/http-builder-ng-core/src/main/java/groovyx/net/http/HttpConfigs.java
+++ b/http-builder-ng-core/src/main/java/groovyx/net/http/HttpConfigs.java
@@ -142,6 +142,10 @@ public class HttpConfigs {
             getUri().setFull(val);
         }
 
+        public void setRaw(final String val){
+
+        }
+
         public void setUri(final URI val) {
             getUri().setFull(val);
         }

--- a/http-builder-ng-core/src/main/java/groovyx/net/http/UriBuilder.java
+++ b/http-builder-ng-core/src/main/java/groovyx/net/http/UriBuilder.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2017 HttpBuilder-NG Project
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -278,6 +278,7 @@ public abstract class UriBuilder {
         }
     }
 
+    // does not do any encoding
     private static Map<String, Collection<String>> extractQueryMap(final String queryString){
         final Map<String,Collection<String>> map = new HashMap<>();
 

--- a/http-builder-ng-core/src/main/java/groovyx/net/http/UriBuilder.java
+++ b/http-builder-ng-core/src/main/java/groovyx/net/http/UriBuilder.java
@@ -199,11 +199,12 @@ public abstract class UriBuilder {
         final String fragment = traverse(this, UriBuilder::getParent, UriBuilder::getFragment, Traverser::notNull);
         final String userInfo = traverse(this, UriBuilder::getParent, UriBuilder::getUserInfo, Traverser::notNull);
 
-        if (useRawValues) {
+        if(useRawValues) {
             return toRawURI(scheme, port, host, path, query, fragment, userInfo);
         }
-
-        return new URI(scheme, userInfo, host, (port == null ? -1 : port), ((path == null) ? null : path.toString()), query, fragment);
+        else {
+            return new URI(scheme, userInfo, host, (port == null ? -1 : port), ((path == null) ? null : path.toString()), query, fragment);
+        }
     }
 
     private URI toRawURI(final String scheme, final Integer port, final String host, final GString path, final String query, final String fragment, final String userInfo) throws URISyntaxException {

--- a/http-builder-ng-core/src/main/java/groovyx/net/http/UriBuilder.java
+++ b/http-builder-ng-core/src/main/java/groovyx/net/http/UriBuilder.java
@@ -40,7 +40,7 @@ import static java.util.Collections.singletonList;
 
 /**
  * Provides a simple means of creating a request URI and optionally overriding its parts.
- * <p>
+ *
  * [source,groovy]
  * ----
  * def uri = UriBuilder.basic(UriBuilder.root())
@@ -48,7 +48,7 @@ import static java.util.Collections.singletonList;
  * .setPath('/foo')
  * .toURI()
  * ----
- * <p>
+ *
  * Generally, this class is not instantiated directly, but created by the {@link HttpConfig} instance and modified.
  */
 public abstract class UriBuilder {
@@ -323,14 +323,14 @@ public abstract class UriBuilder {
     /**
      * Creates a basic `UriBuilder` from the provided parent builder. An empty `UriBuilder` may be created using the `root()` method as the `parent` value,
      * otherwise a new `UriBuilder` may be created from an existing builder:
-     * <p>
+     *
      * [source,groovy]
      * ----
      * def parent = UriBuilder.basic(UriBuilder.root()).setFull('http://localhost:10101/foo')
      * def child = UriBuilder.basic(parent)
      * child.setPath('/bar').toURI() == new URI('http://localhost:10101/bar')
      * ----
-     * <p>
+     *
      * The `UriBuilder` implementation generated with this method is _not_ thread-safe.
      *
      * @param parent the `UriBuilder` parent
@@ -343,14 +343,14 @@ public abstract class UriBuilder {
     /**
      * Creates a thread-safe `UriBuilder` from the provided parent builder. An empty `UriBuilder` may be created using the `root()` method as the
      * `parent` value, otherwise a new `UriBuilder` may be created from an existing builder:
-     * <p>
+     *
      * [source,groovy]
      * ----
      * def parent = UriBuilder.threadSafe(UriBuilder.root()).setFull('http://localhost:10101/foo')
      * def child = UriBuilder.threadSafe(parent)
      * child.setPath('/bar').toURI() == new URI('http://localhost:10101/bar')
      * ----
-     * <p>
+     * 
      * The `UriBuilder` implementation generated with this method is thread-safe.
      *
      * @param parent the `UriBuilder` parent
@@ -544,6 +544,3 @@ public abstract class UriBuilder {
         }
     }
 }
-
-
-

--- a/http-builder-ng-core/src/test/groovy/groovyx/net/http/UriBuilderSpec.groovy
+++ b/http-builder-ng-core/src/test/groovy/groovyx/net/http/UriBuilderSpec.groovy
@@ -15,14 +15,13 @@
  */
 package groovyx.net.http
 
-import com.stehno.ersatz.ContentType
 import com.stehno.ersatz.Encoders
 import com.stehno.ersatz.ErsatzServer
 import spock.lang.Specification
 
 import static com.stehno.ersatz.ContentType.TEXT_PLAIN
 import static groovyx.net.http.UriBuilder.basic
-import static groovyx.net.http.UriBuilder.root;
+import static groovyx.net.http.UriBuilder.root
 
 class UriBuilderSpec extends Specification {
 
@@ -192,12 +191,28 @@ class UriBuilderSpec extends Specification {
 
         when:
         builder.full = raw
-//        URI uri = builder.toRawURI()
         URI uri = builder.toURI()
 
         then:
         uri == raw.toURI()
         uri.rawPath == '/api/v4/projects/myteam%2Fmyrepo/repository/files/myfile.json'
+    }
+
+    def 'url with encoded query'(){
+        setup:
+        String raw = 'http://localhost:8181/api/v4/projects/myteam%2Fmyrepo/repository/files/myfile.json?ref=master%2Fone&alpha=bravo'
+
+        UriBuilder builder = basic(root())
+        builder.useRawValues = true
+
+        when:
+        builder.full = raw
+        URI uri = builder.toURI()
+
+        then:
+        uri == raw.toURI()
+        uri.rawPath == '/api/v4/projects/myteam%2Fmyrepo/repository/files/myfile.json'
+        uri.rawQuery == 'ref=master%2Fone&alpha=bravo'
     }
 
     def 'url with encoded slash (2)'(){
@@ -210,7 +225,7 @@ class UriBuilderSpec extends Specification {
 
         when:
         def result = JavaHttpBuilder.configure {
-            request.uri = "${server.httpUrl}/api/v4/projects/myteam%2Fmyrepo/repository/files/myfile.json"
+            request.raw = "${server.httpUrl}/api/v4/projects/myteam%2Fmyrepo/repository/files/myfile.json"
         }.get()
 
         then:
@@ -227,9 +242,9 @@ class UriBuilderSpec extends Specification {
 
         when:
         def result = JavaHttpBuilder.configure {
-            request.uri = "${server.httpUrl}/api/v4/projects/myteam%2Fmyrepo/repository/files"
+            request.raw = server.httpUrl
         }.get {
-            request.uri.path = '/myfile.json'
+            request.uri.path = '/api/v4/projects/myteam%2Fmyrepo/repository/files/myfile.json'
         }
 
         then:

--- a/http-builder-ng-core/src/test/groovy/groovyx/net/http/UriBuilderSpec.groovy
+++ b/http-builder-ng-core/src/test/groovy/groovyx/net/http/UriBuilderSpec.groovy
@@ -17,13 +17,20 @@ package groovyx.net.http
 
 import com.stehno.ersatz.Encoders
 import com.stehno.ersatz.ErsatzServer
+import groovyx.net.http.optional.Download
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
 
+import static com.stehno.ersatz.ContentType.TEXT_JSON
 import static com.stehno.ersatz.ContentType.TEXT_PLAIN
 import static groovyx.net.http.UriBuilder.basic
 import static groovyx.net.http.UriBuilder.root
+import static groovyx.net.http.util.SslUtils.ignoreSslIssues
 
 class UriBuilderSpec extends Specification {
+
+    @Rule TemporaryFolder folder = new TemporaryFolder()
 
     def 'root yields empty URI'() {
         expect:
@@ -182,7 +189,7 @@ class UriBuilderSpec extends Specification {
         server.stop()
     }
 
-    def 'url with encoded slash'(){
+    def 'url with encoded slash'() {
         setup:
         String raw = 'http://localhost:8181/api/v4/projects/myteam%2Fmyrepo/repository/files/myfile.json?ref=master'
 
@@ -198,7 +205,7 @@ class UriBuilderSpec extends Specification {
         uri.rawPath == '/api/v4/projects/myteam%2Fmyrepo/repository/files/myfile.json'
     }
 
-    def 'url with encoded query'(){
+    def 'url with encoded query'() {
         setup:
         String raw = 'http://localhost:8181/api/v4/projects/myteam%2Fmyrepo/repository/files/myfile.json?ref=master%2Fone&alpha=bravo'
 
@@ -215,7 +222,7 @@ class UriBuilderSpec extends Specification {
         uri.rawQuery == 'ref=master%2Fone&alpha=bravo'
     }
 
-    def 'url with encoded slash (2)'(){
+    def 'url with encoded slash (2)'() {
         setup:
         def server = new ErsatzServer({
             expectations {
@@ -232,7 +239,7 @@ class UriBuilderSpec extends Specification {
         result == 'ok'
     }
 
-    def 'url with encoded slash (3)'(){
+    def 'url with encoded slash (3)'() {
         setup:
         def server = new ErsatzServer({
             expectations {
@@ -249,5 +256,60 @@ class UriBuilderSpec extends Specification {
 
         then:
         result == 'ok'
+    }
+
+    def 'another encoded uri test'() {
+        setup:
+        String apiNamespace = 'something'
+        String apiRepoName = 'somewhere'
+        String gitFilePath = 'thefile'
+        String apiToken = 'asdfasdfasdf'
+
+        File dir = folder.newFolder()
+
+        def server = new ErsatzServer({
+            https()
+            expectations {
+                get("/api/v4/projects/${apiNamespace}%2F${apiRepoName}/repository/files/${gitFilePath}/salt-api_request.json") {
+                    query 'ref', 'master'
+                    protocol 'HTTPS'
+                    called 1
+                    responder {
+                        code 200
+                        content '{"value":"ok"}', TEXT_JSON
+                    }
+                }
+            }
+        })
+
+        when:
+        boolean hasFailure = false
+
+        JavaHttpBuilder.configure {
+            request.raw = "${server.httpsUrl}/api/v4/projects/${apiNamespace}%2F${apiRepoName}/repository/files/${gitFilePath}/salt-api_request.json?ref=master"
+            request.contentType = 'application/json'
+            request.accept = 'application/json'
+            request.headers['PRIVATE-TOKEN'] = apiToken
+
+            ignoreSslIssues execution
+
+            response.failure { FromServer fs, Object body ->
+                hasFailure = true
+            }
+
+        }.get {
+            Download.toFile(delegate as HttpConfig, new File(dir, 'salt-api_request.json'))
+        }
+
+        then: 'there is no failure'
+        !hasFailure
+
+        and: 'the file has the expected content'
+        def file = new File(dir, 'salt-api_request.json')
+        file.exists()
+        file.text == '{"value":"ok"}'
+
+        and: 'the server was actually called'
+        server.verify()
     }
 }

--- a/src/docs/asciidoc/configuration.adoc
+++ b/src/docs/asciidoc/configuration.adoc
@@ -56,6 +56,18 @@ HttpBuilder.configure {
 }
 ----
 
+An alternate means of specifying the `URI` is the `setRaw(String)` method. This method does not encoding or decoding of the given URI string and any such encoding/decoding must be performed in
+provided URI string itself. This is useful for the case where there are encoded elements within a URI path, such as:
+
+[source,groovy]
+----
+def result = HttpBuilder.configure {
+    request.raw = "${server.httpUrl}/api/v4/projects/myteam%2Fmyrepo/repository/files/myfile.json"
+}.get()
+----
+
+Note that the `myteam%2Fmyrepo` part of the path will remain unchanged in the resulting URI.
+
 ===== Cookies
 
 https://en.wikipedia.org/wiki/HTTP_cookie[HTTP Cookies] may be configured on a request using one of the cookie configuration methods on the

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -183,6 +183,7 @@ include::troubleshooting.adoc[]
 == Unsupported Features
 
 * The `core` library implementation does not support the `PATCH` request method due to limitations of the underlying client library.
+* The `TRACE` request method does not support HTTPS requests.
 
 == Contributors
 

--- a/src/docs/asciidoc/troubleshooting.adoc
+++ b/src/docs/asciidoc/troubleshooting.adoc
@@ -21,3 +21,24 @@ you can extract the `typecheckhttpconfig.groovy` and `59f7b2e5d5a78b25c6b21eb3b6
 add them to the application's war root classpath.
 
 If neither of these solve the problem for you, please feel free to create an issue, but please provide a working example that we can test against.
+
+=== Encoded URI Path
+
+In some cases HTTP server endpoints will have encoded portions of the path so that you end up with a URI such as:
+
+    http://localhost:1234/api/v4/projects/myteam%2Fmyrepo/repository/files/myfile.json
+
+Notice the `myteam%2Fmyrepo` is a URI-encoded string. Using the standard `request.uri` approach with this URI will fail since the encoding will be decoded when used to create the URI. We have provided
+and alternate approach to solve this problem (see <<_uri>> Configuration section). Using the `request.raw` configuration option, you can specify a "raw" URI string which will preserve any
+encoding. In fact, it will perform _no_ encoding or decoding of path or query string elements, so it all must be done in your provided URI string.
+
+An example of this approach would be:
+
+[source,groovy]
+----
+def result = JavaHttpBuilder.configure {
+    request.raw = "http://localhost:1234/api/v4/projects/myteam%2Fmyrepo/repository/files/myfile.json"
+}.get()
+----
+
+which would properly preserve the encoded URI content.


### PR DESCRIPTION
@PredatorVI this should fix your issue. I will leave this branch available after I merge if you want to test it yourself, otherwise it will be part of the 1.0.0 release which will drop sometime early to mid next week (if not sooner).

@dwclark how about this? I took a hybrid approach. Basically there is an alternate means of specifying the uri in the builder, `request.raw` that will use the raw builder approach (the doc changes are in the PR too). For the "raw" approach I build the string version of the URI from its parts (similar to PredatorVI's approach). This passes the tests and seems to solve the problem with little fuss.