### PR TITLE
Clarify status handler signature sample code in documentation

### DIFF
--- a/src/docs/asciidoc/configuration.adoc
+++ b/src/docs/asciidoc/configuration.adoc
@@ -278,7 +278,7 @@ will be called with the `FromServer` instance and an `Object` instance, which wi
 HttpBuilder.configure {
     request.uri = 'http://localhost:8181'
 }.head {
-    response.when(200){ FromServer fs ->
+    response.when(200){ FromServer fs, Object body ->
         'ok'
     }
 }
@@ -296,7 +296,7 @@ The other two status handlers are the `success` and `failure` methods:
 HttpBuilder.configure {
     request.uri = 'http://localhost:8181'
 }.head {
-    response.success { FromServer fs ->
+    response.success { FromServer fs, Object body ->
         'ok'
     }
 }


### PR DESCRIPTION
Changed 
```groovy
HttpBuilder.configure {
    request.uri = 'http://localhost:8181'
}.head {
    response.when(200){ FromServer fs ->
        'ok'
    }
}
```
to
```groovy
HttpBuilder.configure {
    request.uri = 'http://localhost:8181'
}.head {
    response.when(200){ FromServer fs, Object body ->
        'ok'
    }
}
```
to make the sample code a little more clear, since the indication that there is a second argument to the status handler closure is easy to miss in the paragraph above. 

Fixes https://github.com/http-builder-ng/http-builder-ng/issues/199