### PR TITLE
Fix travis-ci build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+dist: trusty
 install: true
 jdk: oraclejdk8
 env:


### PR DESCRIPTION
Since xenial is now default on travis-ci and xenial no longer supports oracle-jdk-8, the distribution  or JDK needs to be changed in `.travis.yml` (`dist` to `trusty` or `jdk` to `openjdk8`)
See: https://travis-ci.community/t/error-installing-oraclejdk8-expected-feature-release-number-in-range-of-9-to-14-but-got-8/3766/5

**build before:** https://travis-ci.org/github/bedlaj/http-builder-ng/builds/676703788
`Expected feature release number in range of 9 to 14, but got: 8`
**build after** (with some failing tests and checkstyle violations): https://travis-ci.org/github/bedlaj/http-builder-ng/jobs/676704652